### PR TITLE
Regenerate jumble funcs from Postgres sources using script

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,28 @@ first. Use `sudo make install` for system-wide Postgres installed using packages
 Alternatively, you can use `make installcheck` to test against an already-running
 local Postgres that has `pg_stat_plans` in its `shared_preload_libraries`.
 
+## Regenerating the plan jumble support
+
+The `pg*_jumblefuncs.*.c` files included by `jumblefuncs.c` are generated using
+`src/backend/nodes/gen_node_support.pl` helper in the Postgres source tree, with
+modifications applied to jumble (i.e. hash) Plan trees and calculate the plan ID.
+
+The source branches that are used for this extraction can be found here:
+
+| PostgreSQL | Branch |
+|------------|--------|
+| 16 | [pg-stat-plans-16](https://github.com/lfittl/postgres/tree/pg-stat-plans-16) |
+| 17 | [pg-stat-plans-17](https://github.com/lfittl/postgres/tree/pg-stat-plans-17) |
+| 18 | [pg-stat-plans-18](https://github.com/lfittl/postgres/tree/pg-stat-plans-18) |
+
+The principles behind which fields are jumbled are [documented in the Postgres wiki](https://wiki.postgresql.org/wiki/Plan_ID_Jumbling).
+
+To regenerate the files, run the following, pointing to a local checkout of the right
+branch, and using the correct prefix to be used for the files:
+
+```
+./generate_jumblefuncs.sh pg18 /path/to/postgres
+```
 
 ## Configuration
 

--- a/generate_jumblefuncs.sh
+++ b/generate_jumblefuncs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# generate_jumblefuncs.sh
+#
+# Regenerate the pgNN_jumblefuncs.{switch,funcs}.c files that jumblefuncs.c
+# #includes, from a PostgreSQL source tree.
+#
+# These files are the queryjumblefuncs.{switch,funcs}.c output of PostgreSQL's
+# src/backend/nodes/gen_node_support.pl, renamed per major version. The source
+# tree must be checked out to a branch that carries the pg_stat_plans plan-ID
+# jumble changes (the "Add plan ID jumble funcs" commit: array_size/JUMBLE_ARRAY
+# support in gen_node_support.pl plus the plan-node annotations in
+# plannodes.h / primnodes.h).
+#
+# The generator runs standalone with perl -- no configure/build of PostgreSQL
+# is required, it just parses the node header files.
+#
+# Usage:
+#   ./generate_jumblefuncs.sh pg19 ~/Code/postgres
+#   ./generate_jumblefuncs.sh pg18 /path/to/pg18-src
+#
+# The header list and its required ordering are read from the target tree's own
+# gen_node_support.pl (@all_input_files), so this works across major versions.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 <label e.g. pg19> <path-to-postgres-source>" >&2
+	exit 1
+fi
+
+label=$1
+pgsrc=$2
+here=$(cd "$(dirname "$0")" && pwd)
+
+gen=$pgsrc/src/backend/nodes/gen_node_support.pl
+incdir=$pgsrc/src/include
+
+if [ ! -f "$gen" ]; then
+	echo "error: $gen not found (is '$pgsrc' a PostgreSQL source tree?)" >&2
+	exit 1
+fi
+
+# Extract @all_input_files (the node headers, in the exact order the generator
+# asserts) from the target tree's gen_node_support.pl.
+# (read loop instead of mapfile for bash 3.2 / macOS compatibility)
+headers=()
+while IFS= read -r h; do
+	headers+=("$h")
+done < <(perl -ne '
+	$in = 1 if /\@all_input_files\s*=\s*qw\(/;
+	next unless $in;
+	$in = 0, last if /^\s*\)\s*;/;
+	while (/([\w\/]+\.h)/g) { print "$1\n"; }
+' "$gen")
+
+if [ "${#headers[@]}" -eq 0 ]; then
+	echo "error: could not parse \@all_input_files from $gen" >&2
+	exit 1
+fi
+
+args=()
+for h in "${headers[@]}"; do
+	args+=("$incdir/$h")
+done
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Generating jumble funcs for $label from $pgsrc"
+echo "  branch: $(git -C "$pgsrc" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+echo "  headers: ${#headers[@]}"
+
+(cd "$pgsrc/src/backend/nodes" && perl "$gen" --outdir "$tmp" "${args[@]}")
+
+for kind in switch funcs; do
+	src=$tmp/queryjumblefuncs.$kind.c
+	dst=$here/${label}_jumblefuncs.$kind.c
+	if [ ! -f "$src" ]; then
+		echo "error: generator did not produce $src" >&2
+		exit 1
+	fi
+	cp "$src" "$dst"
+	echo "  wrote $(basename "$dst") ($(wc -l < "$dst") lines)"
+done
+
+echo "Done."

--- a/jumblefuncs.c
+++ b/jumblefuncs.c
@@ -30,7 +30,8 @@ static JumbleState *InitJumbleInternal(bool record_clocations);
 static void AppendJumbleInternal(JumbleState *jstate,
 								 const unsigned char *value, Size size);
 #if PG_VERSION_NUM >= 180000
-static void _jumbleElements(JumbleState *jstate, List *elements);
+static void _jumbleElements(JumbleState *jstate, List *elements, Node *node);
+static void _jumbleParam(JumbleState *jstate, Node *node);
 #endif
 static void _jumbleA_Const(JumbleState *jstate, Node *node);
 static void _jumbleList(JumbleState *jstate, Node *node);
@@ -76,6 +77,9 @@ InitJumbleInternal(bool record_clocations)
 
 	jstate->clocations_count = 0;
 	jstate->highest_extern_param_id = 0;
+#if PG_VERSION_NUM >= 180000
+	jstate->has_squashed_lists = false;
+#endif
 #if PG_VERSION_NUM >= 180000
 	jstate->pending_nulls = 0;
 #ifdef USE_ASSERT_CHECKING
@@ -296,47 +300,74 @@ FlushPendingNulls(JumbleState *jstate)
  * Subroutine for _jumbleElements: Verify a few simple cases where we can
  * deduce that the expression is a constant:
  *
- * - Ignore a possible wrapping RelabelType and CoerceViaIO.
- * - If it's a FuncExpr, check that the function is an implicit
+ * - See through any wrapping RelabelType and CoerceViaIO layers.
+ * - If it's a FuncExpr, check that the function is a builtin
  *   cast and its arguments are Const.
- * - Otherwise test if the expression is a simple Const.
+ * - Otherwise test if the expression is a simple Const or a
+ *   PARAM_EXTERN param.
  */
 static bool
-IsSquashableConst(Node *element)
+IsSquashableConstant(Node *element)
 {
-	if (IsA(element, RelabelType))
-		element = (Node *) ((RelabelType *) element)->arg;
-
-	if (IsA(element, CoerceViaIO))
-		element = (Node *) ((CoerceViaIO *) element)->arg;
-
-	if (IsA(element, FuncExpr))
+restart:
+	switch (nodeTag(element))
 	{
-		FuncExpr   *func = (FuncExpr *) element;
-		ListCell   *temp;
+		case T_RelabelType:
+			/* Unwrap RelabelType */
+			element = (Node *) ((RelabelType *) element)->arg;
+			goto restart;
 
-		if (func->funcformat != COERCE_IMPLICIT_CAST &&
-			func->funcformat != COERCE_EXPLICIT_CAST)
+		case T_CoerceViaIO:
+			/* Unwrap CoerceViaIO */
+			element = (Node *) ((CoerceViaIO *) element)->arg;
+			goto restart;
+
+		case T_Const:
+			return true;
+
+		case T_Param:
+			return castNode(Param, element)->paramkind == PARAM_EXTERN;
+
+		case T_FuncExpr:
+			{
+				FuncExpr   *func = (FuncExpr *) element;
+				ListCell   *temp;
+
+				if (func->funcformat != COERCE_IMPLICIT_CAST &&
+					func->funcformat != COERCE_EXPLICIT_CAST)
+					return false;
+
+				if (func->funcid > FirstGenbkiObjectId)
+					return false;
+
+				/*
+				 * We can check function arguments recursively, being careful
+				 * about recursing too deep.  At each recursion level it's
+				 * enough to test the stack on the first element.  (Note that
+				 * I wasn't able to hit this without bloating the stack
+				 * artificially in this function: the parser errors out before
+				 * stack size becomes a problem here.)
+				 */
+				foreach(temp, func->args)
+				{
+					Node	   *arg = lfirst(temp);
+
+					if (!IsA(arg, Const))
+					{
+						if (foreach_current_index(temp) == 0 &&
+							stack_is_too_deep())
+							return false;
+						else if (!IsSquashableConstant(arg))
+							return false;
+					}
+				}
+
+				return true;
+			}
+
+		default:
 			return false;
-
-		if (func->funcid > FirstGenbkiObjectId)
-			return false;
-
-		foreach(temp, func->args)
-		{
-			Node	   *arg = lfirst(temp);
-
-			if (!IsA(arg, Const))	/* XXX we could recurse here instead */
-				return false;
-		}
-
-		return true;
 	}
-
-	if (!IsA(element, Const))
-		return false;
-
-	return true;
 }
 
 /*
@@ -346,29 +377,23 @@ IsSquashableConst(Node *element)
  * Return value indicates if squashing is possible.
  *
  * Note that this function searches only for explicit Const nodes with
- * possibly very simple decorations on top, and does not try to simplify
- * expressions.
+ * possibly very simple decorations on top and PARAM_EXTERN parameters,
+ * and does not try to simplify expressions.
  */
 static bool
-IsSquashableConstList(List *elements, Node **firstExpr, Node **lastExpr)
+IsSquashableConstantList(List *elements)
 {
 	ListCell   *temp;
 
-	/*
-	 * If squashing is disabled, or the list is too short, we don't try to
-	 * squash it.
-	 */
+	/* If the list is too short, we don't try to squash it. */
 	if (list_length(elements) < 2)
 		return false;
 
 	foreach(temp, elements)
 	{
-		if (!IsSquashableConst(lfirst(temp)))
+		if (!IsSquashableConstant(lfirst(temp)))
 			return false;
 	}
-
-	*firstExpr = linitial(elements);
-	*lastExpr = llast(elements);
 
 	return true;
 }
@@ -377,8 +402,8 @@ IsSquashableConstList(List *elements, Node **firstExpr, Node **lastExpr)
 #define JUMBLE_NODE(item) \
 	JumbleNode(jstate, (Node *) expr->item)
 #if PG_VERSION_NUM >= 180000
-#define JUMBLE_ELEMENTS(list) \
-	_jumbleElements(jstate, (List *) expr->list)
+#define JUMBLE_ELEMENTS(list, node) \
+	_jumbleElements(jstate, (List *) expr->list, node)
 #endif
 #define JUMBLE_LOCATION(location) // Intentionally not recording location
 #define JUMBLE_FIELD(item) \
@@ -436,24 +461,49 @@ do { \
 
 #if PG_VERSION_NUM >= 180000
 /*
- * We jumble lists of constant elements as one individual item regardless
- * of how many elements are in the list.  This means different queries
- * jumble to the same query_id, if the only difference is the number of
- * elements in the list.
+ * We try to jumble lists of expressions as one individual item regardless
+ * of how many elements are in the list. This is know as squashing, which
+ * results in different queries jumbling to the same query_id, if the only
+ * difference is the number of elements in the list.
+ *
+ * We allow constants and PARAM_EXTERN parameters to be squashed. To normalize
+ * such queries, we use the start and end locations of the list of elements in
+ * a list.
  */
 static void
-_jumbleElements(JumbleState *jstate, List *elements)
+_jumbleElements(JumbleState *jstate, List *elements, Node *node)
 {
-	Node	   *first,
-			   *last;
+	bool		normalize_list = false;
 
-	if (IsSquashableConstList(elements, &first, &last))
+	if (IsSquashableConstantList(elements))
 	{
+		if (IsA(node, ArrayExpr))
+		{
+			ArrayExpr  *aexpr = (ArrayExpr *) node;
+
+			if (aexpr->list_start > 0 && aexpr->list_end > 0)
+			{
+				normalize_list = true;
+				jstate->has_squashed_lists = true;
+			}
+		}
 	}
-	else
+
+	if (!normalize_list)
 	{
 		JumbleNode(jstate, (Node *) elements);
 	}
+}
+
+static void
+_jumbleParam(JumbleState *jstate, Node *node)
+{
+	Param	   *expr = (Param *) node;
+
+	JUMBLE_FIELD(paramkind);
+	JUMBLE_FIELD(paramid);
+	JUMBLE_FIELD(paramtype);
+	/* paramtypmod and paramcollid are ignored */
 }
 #endif
 

--- a/pg18_jumblefuncs.funcs.c
+++ b/pg18_jumblefuncs.funcs.c
@@ -42,7 +42,7 @@
 static void
 _jumbleAlias(JumbleState *jstate, Node *node)
 {
-	Alias	   *expr = (Alias *) node;
+	Alias *expr = (Alias *) node;
 
 	JUMBLE_STRING(aliasname);
 	JUMBLE_NODE(colnames);
@@ -51,7 +51,7 @@ _jumbleAlias(JumbleState *jstate, Node *node)
 static void
 _jumbleRangeVar(JumbleState *jstate, Node *node)
 {
-	RangeVar   *expr = (RangeVar *) node;
+	RangeVar *expr = (RangeVar *) node;
 
 	JUMBLE_STRING(catalogname);
 	JUMBLE_STRING(schemaname);
@@ -64,7 +64,7 @@ _jumbleRangeVar(JumbleState *jstate, Node *node)
 static void
 _jumbleTableFunc(JumbleState *jstate, Node *node)
 {
-	TableFunc  *expr = (TableFunc *) node;
+	TableFunc *expr = (TableFunc *) node;
 
 	JUMBLE_FIELD(functype);
 	JUMBLE_NODE(docexpr);
@@ -89,7 +89,7 @@ _jumbleIntoClause(JumbleState *jstate, Node *node)
 static void
 _jumbleVar(JumbleState *jstate, Node *node)
 {
-	Var		   *expr = (Var *) node;
+	Var *expr = (Var *) node;
 
 	JUMBLE_FIELD(varno);
 	JUMBLE_FIELD(varattno);
@@ -100,26 +100,16 @@ _jumbleVar(JumbleState *jstate, Node *node)
 static void
 _jumbleConst(JumbleState *jstate, Node *node)
 {
-	Const	   *expr = (Const *) node;
+	Const *expr = (Const *) node;
 
 	JUMBLE_FIELD(consttype);
 	JUMBLE_LOCATION(location);
 }
 
 static void
-_jumbleParam(JumbleState *jstate, Node *node)
-{
-	Param	   *expr = (Param *) node;
-
-	JUMBLE_FIELD(paramkind);
-	JUMBLE_FIELD(paramid);
-	JUMBLE_FIELD(paramtype);
-}
-
-static void
 _jumbleAggref(JumbleState *jstate, Node *node)
 {
-	Aggref	   *expr = (Aggref *) node;
+	Aggref *expr = (Aggref *) node;
 
 	JUMBLE_FIELD(aggfnoid);
 	JUMBLE_NODE(aggdirectargs);
@@ -182,7 +172,7 @@ _jumbleSubscriptingRef(JumbleState *jstate, Node *node)
 static void
 _jumbleFuncExpr(JumbleState *jstate, Node *node)
 {
-	FuncExpr   *expr = (FuncExpr *) node;
+	FuncExpr *expr = (FuncExpr *) node;
 
 	JUMBLE_FIELD(funcid);
 	JUMBLE_NODE(args);
@@ -200,7 +190,7 @@ _jumbleNamedArgExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleOpExpr(JumbleState *jstate, Node *node)
 {
-	OpExpr	   *expr = (OpExpr *) node;
+	OpExpr *expr = (OpExpr *) node;
 
 	JUMBLE_FIELD(opno);
 	JUMBLE_NODE(args);
@@ -237,7 +227,7 @@ _jumbleScalarArrayOpExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleBoolExpr(JumbleState *jstate, Node *node)
 {
-	BoolExpr   *expr = (BoolExpr *) node;
+	BoolExpr *expr = (BoolExpr *) node;
 
 	JUMBLE_FIELD(boolop);
 	JUMBLE_NODE(args);
@@ -246,7 +236,7 @@ _jumbleBoolExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleSubLink(JumbleState *jstate, Node *node)
 {
-	SubLink    *expr = (SubLink *) node;
+	SubLink *expr = (SubLink *) node;
 
 	JUMBLE_FIELD(subLinkType);
 	JUMBLE_FIELD(subLinkId);
@@ -257,7 +247,7 @@ _jumbleSubLink(JumbleState *jstate, Node *node)
 static void
 _jumbleSubPlan(JumbleState *jstate, Node *node)
 {
-	SubPlan    *expr = (SubPlan *) node;
+	SubPlan *expr = (SubPlan *) node;
 
 	JUMBLE_FIELD(subLinkType);
 	JUMBLE_NODE(testexpr);
@@ -342,7 +332,7 @@ _jumbleCollateExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleCaseExpr(JumbleState *jstate, Node *node)
 {
-	CaseExpr   *expr = (CaseExpr *) node;
+	CaseExpr *expr = (CaseExpr *) node;
 
 	JUMBLE_NODE(arg);
 	JUMBLE_NODE(args);
@@ -352,7 +342,7 @@ _jumbleCaseExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleCaseWhen(JumbleState *jstate, Node *node)
 {
-	CaseWhen   *expr = (CaseWhen *) node;
+	CaseWhen *expr = (CaseWhen *) node;
 
 	JUMBLE_NODE(expr);
 	JUMBLE_NODE(result);
@@ -369,15 +359,15 @@ _jumbleCaseTestExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleArrayExpr(JumbleState *jstate, Node *node)
 {
-	ArrayExpr  *expr = (ArrayExpr *) node;
+	ArrayExpr *expr = (ArrayExpr *) node;
 
-	JUMBLE_ELEMENTS(elements);
+	JUMBLE_ELEMENTS(elements, node);
 }
 
 static void
 _jumbleRowExpr(JumbleState *jstate, Node *node)
 {
-	RowExpr    *expr = (RowExpr *) node;
+	RowExpr *expr = (RowExpr *) node;
 
 	JUMBLE_NODE(args);
 }
@@ -421,7 +411,7 @@ _jumbleSQLValueFunction(JumbleState *jstate, Node *node)
 static void
 _jumbleXmlExpr(JumbleState *jstate, Node *node)
 {
-	XmlExpr    *expr = (XmlExpr *) node;
+	XmlExpr *expr = (XmlExpr *) node;
 
 	JUMBLE_FIELD(op);
 	JUMBLE_NODE(named_args);
@@ -496,7 +486,7 @@ _jumbleJsonBehavior(JumbleState *jstate, Node *node)
 static void
 _jumbleJsonExpr(JumbleState *jstate, Node *node)
 {
-	JsonExpr   *expr = (JsonExpr *) node;
+	JsonExpr *expr = (JsonExpr *) node;
 
 	JUMBLE_FIELD(op);
 	JUMBLE_STRING(column_name);
@@ -548,7 +538,7 @@ _jumbleJsonTableSiblingJoin(JumbleState *jstate, Node *node)
 static void
 _jumbleNullTest(JumbleState *jstate, Node *node)
 {
-	NullTest   *expr = (NullTest *) node;
+	NullTest *expr = (NullTest *) node;
 
 	JUMBLE_NODE(arg);
 	JUMBLE_FIELD(nulltesttype);
@@ -659,7 +649,7 @@ _jumbleRangeTblRef(JumbleState *jstate, Node *node)
 static void
 _jumbleJoinExpr(JumbleState *jstate, Node *node)
 {
-	JoinExpr   *expr = (JoinExpr *) node;
+	JoinExpr *expr = (JoinExpr *) node;
 
 	JUMBLE_FIELD(jointype);
 	JUMBLE_FIELD(isNatural);
@@ -672,7 +662,7 @@ _jumbleJoinExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleFromExpr(JumbleState *jstate, Node *node)
 {
-	FromExpr   *expr = (FromExpr *) node;
+	FromExpr *expr = (FromExpr *) node;
 
 	JUMBLE_NODE(fromlist);
 	JUMBLE_NODE(quals);
@@ -696,7 +686,7 @@ _jumbleOnConflictExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleQuery(JumbleState *jstate, Node *node)
 {
-	Query	   *expr = (Query *) node;
+	Query *expr = (Query *) node;
 
 	JUMBLE_FIELD(commandType);
 	JUMBLE_NODE(utilityStmt);
@@ -725,7 +715,7 @@ _jumbleQuery(JumbleState *jstate, Node *node)
 static void
 _jumbleTypeName(JumbleState *jstate, Node *node)
 {
-	TypeName   *expr = (TypeName *) node;
+	TypeName *expr = (TypeName *) node;
 
 	JUMBLE_NODE(names);
 	JUMBLE_FIELD(typeOid);
@@ -739,7 +729,7 @@ _jumbleTypeName(JumbleState *jstate, Node *node)
 static void
 _jumbleColumnRef(JumbleState *jstate, Node *node)
 {
-	ColumnRef  *expr = (ColumnRef *) node;
+	ColumnRef *expr = (ColumnRef *) node;
 
 	JUMBLE_NODE(fields);
 }
@@ -747,7 +737,7 @@ _jumbleColumnRef(JumbleState *jstate, Node *node)
 static void
 _jumbleParamRef(JumbleState *jstate, Node *node)
 {
-	ParamRef   *expr = (ParamRef *) node;
+	ParamRef *expr = (ParamRef *) node;
 
 	JUMBLE_FIELD(number);
 }
@@ -755,7 +745,7 @@ _jumbleParamRef(JumbleState *jstate, Node *node)
 static void
 _jumbleA_Expr(JumbleState *jstate, Node *node)
 {
-	A_Expr	   *expr = (A_Expr *) node;
+	A_Expr *expr = (A_Expr *) node;
 
 	JUMBLE_FIELD(kind);
 	JUMBLE_NODE(name);
@@ -766,7 +756,7 @@ _jumbleA_Expr(JumbleState *jstate, Node *node)
 static void
 _jumbleTypeCast(JumbleState *jstate, Node *node)
 {
-	TypeCast   *expr = (TypeCast *) node;
+	TypeCast *expr = (TypeCast *) node;
 
 	JUMBLE_NODE(arg);
 	JUMBLE_NODE(typeName);
@@ -784,7 +774,7 @@ _jumbleCollateClause(JumbleState *jstate, Node *node)
 static void
 _jumbleRoleSpec(JumbleState *jstate, Node *node)
 {
-	RoleSpec   *expr = (RoleSpec *) node;
+	RoleSpec *expr = (RoleSpec *) node;
 
 	JUMBLE_FIELD(roletype);
 	JUMBLE_STRING(rolename);
@@ -793,7 +783,7 @@ _jumbleRoleSpec(JumbleState *jstate, Node *node)
 static void
 _jumbleFuncCall(JumbleState *jstate, Node *node)
 {
-	FuncCall   *expr = (FuncCall *) node;
+	FuncCall *expr = (FuncCall *) node;
 
 	JUMBLE_NODE(funcname);
 	JUMBLE_NODE(args);
@@ -810,7 +800,7 @@ _jumbleFuncCall(JumbleState *jstate, Node *node)
 static void
 _jumbleA_Star(JumbleState *jstate, Node *node)
 {
-	A_Star	   *expr = (A_Star *) node;
+	A_Star *expr = (A_Star *) node;
 
 	(void) expr;
 }
@@ -818,7 +808,7 @@ _jumbleA_Star(JumbleState *jstate, Node *node)
 static void
 _jumbleA_Indices(JumbleState *jstate, Node *node)
 {
-	A_Indices  *expr = (A_Indices *) node;
+	A_Indices *expr = (A_Indices *) node;
 
 	JUMBLE_FIELD(is_slice);
 	JUMBLE_NODE(lidx);
@@ -845,7 +835,7 @@ _jumbleA_ArrayExpr(JumbleState *jstate, Node *node)
 static void
 _jumbleResTarget(JumbleState *jstate, Node *node)
 {
-	ResTarget  *expr = (ResTarget *) node;
+	ResTarget *expr = (ResTarget *) node;
 
 	JUMBLE_STRING(name);
 	JUMBLE_NODE(indirection);
@@ -865,7 +855,7 @@ _jumbleMultiAssignRef(JumbleState *jstate, Node *node)
 static void
 _jumbleSortBy(JumbleState *jstate, Node *node)
 {
-	SortBy	   *expr = (SortBy *) node;
+	SortBy *expr = (SortBy *) node;
 
 	JUMBLE_NODE(node);
 	JUMBLE_FIELD(sortby_dir);
@@ -876,7 +866,7 @@ _jumbleSortBy(JumbleState *jstate, Node *node)
 static void
 _jumbleWindowDef(JumbleState *jstate, Node *node)
 {
-	WindowDef  *expr = (WindowDef *) node;
+	WindowDef *expr = (WindowDef *) node;
 
 	JUMBLE_STRING(name);
 	JUMBLE_STRING(refname);
@@ -950,7 +940,7 @@ _jumbleRangeTableSample(JumbleState *jstate, Node *node)
 static void
 _jumbleColumnDef(JumbleState *jstate, Node *node)
 {
-	ColumnDef  *expr = (ColumnDef *) node;
+	ColumnDef *expr = (ColumnDef *) node;
 
 	JUMBLE_STRING(colname);
 	JUMBLE_NODE(typeName);
@@ -985,7 +975,7 @@ _jumbleTableLikeClause(JumbleState *jstate, Node *node)
 static void
 _jumbleIndexElem(JumbleState *jstate, Node *node)
 {
-	IndexElem  *expr = (IndexElem *) node;
+	IndexElem *expr = (IndexElem *) node;
 
 	JUMBLE_STRING(name);
 	JUMBLE_NODE(expr);
@@ -1000,7 +990,7 @@ _jumbleIndexElem(JumbleState *jstate, Node *node)
 static void
 _jumbleDefElem(JumbleState *jstate, Node *node)
 {
-	DefElem    *expr = (DefElem *) node;
+	DefElem *expr = (DefElem *) node;
 
 	JUMBLE_STRING(defnamespace);
 	JUMBLE_STRING(defname);
@@ -1088,7 +1078,6 @@ _jumbleRangeTblEntry(JumbleState *jstate, Node *node)
 	RangeTblEntry *expr = (RangeTblEntry *) node;
 
 	JUMBLE_CUSTOM(RangeTblEntry, eref);
-	JUMBLE_NODE(eref);
 	JUMBLE_FIELD(rtekind);
 	JUMBLE_FIELD(inh);
 	JUMBLE_NODE(tablesample);
@@ -1101,6 +1090,7 @@ _jumbleRangeTblEntry(JumbleState *jstate, Node *node)
 	JUMBLE_STRING(ctename);
 	JUMBLE_FIELD(ctelevelsup);
 	JUMBLE_STRING(enrname);
+	JUMBLE_NODE(groupexprs);
 }
 
 static void
@@ -1345,7 +1335,7 @@ _jumbleJsonTablePathSpec(JumbleState *jstate, Node *node)
 static void
 _jumbleJsonTable(JumbleState *jstate, Node *node)
 {
-	JsonTable  *expr = (JsonTable *) node;
+	JsonTable *expr = (JsonTable *) node;
 
 	JUMBLE_NODE(context_item);
 	JUMBLE_NODE(pathspec);
@@ -1516,7 +1506,7 @@ _jumbleUpdateStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleMergeStmt(JumbleState *jstate, Node *node)
 {
-	MergeStmt  *expr = (MergeStmt *) node;
+	MergeStmt *expr = (MergeStmt *) node;
 
 	JUMBLE_NODE(relation);
 	JUMBLE_NODE(sourceRelation);
@@ -1668,7 +1658,7 @@ _jumbleAlterDomainStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleGrantStmt(JumbleState *jstate, Node *node)
 {
-	GrantStmt  *expr = (GrantStmt *) node;
+	GrantStmt *expr = (GrantStmt *) node;
 
 	JUMBLE_FIELD(is_grant);
 	JUMBLE_FIELD(targtype);
@@ -1726,7 +1716,7 @@ _jumbleAlterDefaultPrivilegesStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleCopyStmt(JumbleState *jstate, Node *node)
 {
-	CopyStmt   *expr = (CopyStmt *) node;
+	CopyStmt *expr = (CopyStmt *) node;
 
 	JUMBLE_NODE(relation);
 	JUMBLE_NODE(query);
@@ -2216,7 +2206,7 @@ _jumbleAlterOpFamilyStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleDropStmt(JumbleState *jstate, Node *node)
 {
-	DropStmt   *expr = (DropStmt *) node;
+	DropStmt *expr = (DropStmt *) node;
 
 	JUMBLE_NODE(objects);
 	JUMBLE_FIELD(removeType);
@@ -2277,7 +2267,7 @@ _jumbleClosePortalStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleFetchStmt(JumbleState *jstate, Node *node)
 {
-	FetchStmt  *expr = (FetchStmt *) node;
+	FetchStmt *expr = (FetchStmt *) node;
 
 	JUMBLE_FIELD(direction);
 	JUMBLE_FIELD(howMany);
@@ -2288,7 +2278,7 @@ _jumbleFetchStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleIndexStmt(JumbleState *jstate, Node *node)
 {
-	IndexStmt  *expr = (IndexStmt *) node;
+	IndexStmt *expr = (IndexStmt *) node;
 
 	JUMBLE_STRING(idxname);
 	JUMBLE_NODE(relation);
@@ -2334,7 +2324,7 @@ _jumbleCreateStatsStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleStatsElem(JumbleState *jstate, Node *node)
 {
-	StatsElem  *expr = (StatsElem *) node;
+	StatsElem *expr = (StatsElem *) node;
 
 	JUMBLE_STRING(name);
 	JUMBLE_NODE(expr);
@@ -2388,7 +2378,7 @@ _jumbleAlterFunctionStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleDoStmt(JumbleState *jstate, Node *node)
 {
-	DoStmt	   *expr = (DoStmt *) node;
+	DoStmt *expr = (DoStmt *) node;
 
 	JUMBLE_NODE(args);
 }
@@ -2396,7 +2386,7 @@ _jumbleDoStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleCallStmt(JumbleState *jstate, Node *node)
 {
-	CallStmt   *expr = (CallStmt *) node;
+	CallStmt *expr = (CallStmt *) node;
 
 	JUMBLE_NODE(funcexpr);
 	JUMBLE_NODE(outargs);
@@ -2473,7 +2463,7 @@ _jumbleAlterTypeStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleRuleStmt(JumbleState *jstate, Node *node)
 {
-	RuleStmt   *expr = (RuleStmt *) node;
+	RuleStmt *expr = (RuleStmt *) node;
 
 	JUMBLE_NODE(relation);
 	JUMBLE_STRING(rulename);
@@ -2563,7 +2553,7 @@ _jumbleAlterEnumStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleViewStmt(JumbleState *jstate, Node *node)
 {
-	ViewStmt   *expr = (ViewStmt *) node;
+	ViewStmt *expr = (ViewStmt *) node;
 
 	JUMBLE_NODE(view);
 	JUMBLE_NODE(aliases);
@@ -2576,7 +2566,7 @@ _jumbleViewStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleLoadStmt(JumbleState *jstate, Node *node)
 {
-	LoadStmt   *expr = (LoadStmt *) node;
+	LoadStmt *expr = (LoadStmt *) node;
 
 	JUMBLE_STRING(filename);
 }
@@ -2714,7 +2704,7 @@ _jumbleDiscardStmt(JumbleState *jstate, Node *node)
 static void
 _jumbleLockStmt(JumbleState *jstate, Node *node)
 {
-	LockStmt   *expr = (LockStmt *) node;
+	LockStmt *expr = (LockStmt *) node;
 
 	JUMBLE_NODE(relations);
 	JUMBLE_FIELD(mode);
@@ -2934,7 +2924,7 @@ _jumbleGroupByOrdering(JumbleState *jstate, Node *node)
 static void
 _jumbleResult(JumbleState *jstate, Node *node)
 {
-	Result	   *expr = (Result *) node;
+	Result *expr = (Result *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -2983,8 +2973,6 @@ _jumbleModifyTable(JumbleState *jstate, Node *node)
 	JUMBLE_NODE(resultRelations);
 	JUMBLE_NODE(updateColnosLists);
 	JUMBLE_NODE(withCheckOptionLists);
-	JUMBLE_STRING(returningOldAlias);
-	JUMBLE_STRING(returningNewAlias);
 	JUMBLE_NODE(returningLists);
 	JUMBLE_BITMAPSET(fdwDirectModifyPlans);
 	JUMBLE_NODE(rowMarks);
@@ -3003,7 +2991,7 @@ _jumbleModifyTable(JumbleState *jstate, Node *node)
 static void
 _jumbleAppend(JumbleState *jstate, Node *node)
 {
-	Append	   *expr = (Append *) node;
+	Append *expr = (Append *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3064,7 +3052,7 @@ _jumbleRecursiveUnion(JumbleState *jstate, Node *node)
 static void
 _jumbleBitmapAnd(JumbleState *jstate, Node *node)
 {
-	BitmapAnd  *expr = (BitmapAnd *) node;
+	BitmapAnd *expr = (BitmapAnd *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3079,7 +3067,7 @@ _jumbleBitmapAnd(JumbleState *jstate, Node *node)
 static void
 _jumbleBitmapOr(JumbleState *jstate, Node *node)
 {
-	BitmapOr   *expr = (BitmapOr *) node;
+	BitmapOr *expr = (BitmapOr *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3095,7 +3083,7 @@ _jumbleBitmapOr(JumbleState *jstate, Node *node)
 static void
 _jumbleSeqScan(JumbleState *jstate, Node *node)
 {
-	SeqScan    *expr = (SeqScan *) node;
+	SeqScan *expr = (SeqScan *) node;
 
 	JUMBLE_FIELD(scan.plan.parallel_aware);
 	JUMBLE_FIELD(scan.plan.parallel_safe);
@@ -3128,7 +3116,7 @@ _jumbleSampleScan(JumbleState *jstate, Node *node)
 static void
 _jumbleIndexScan(JumbleState *jstate, Node *node)
 {
-	IndexScan  *expr = (IndexScan *) node;
+	IndexScan *expr = (IndexScan *) node;
 
 	JUMBLE_FIELD(scan.plan.parallel_aware);
 	JUMBLE_FIELD(scan.plan.parallel_safe);
@@ -3210,7 +3198,7 @@ _jumbleBitmapHeapScan(JumbleState *jstate, Node *node)
 static void
 _jumbleTidScan(JumbleState *jstate, Node *node)
 {
-	TidScan    *expr = (TidScan *) node;
+	TidScan *expr = (TidScan *) node;
 
 	JUMBLE_FIELD(scan.plan.parallel_aware);
 	JUMBLE_FIELD(scan.plan.parallel_safe);
@@ -3313,7 +3301,7 @@ _jumbleTableFuncScan(JumbleState *jstate, Node *node)
 static void
 _jumbleCteScan(JumbleState *jstate, Node *node)
 {
-	CteScan    *expr = (CteScan *) node;
+	CteScan *expr = (CteScan *) node;
 
 	JUMBLE_FIELD(scan.plan.parallel_aware);
 	JUMBLE_FIELD(scan.plan.parallel_safe);
@@ -3412,7 +3400,7 @@ _jumbleCustomScan(JumbleState *jstate, Node *node)
 static void
 _jumbleNestLoop(JumbleState *jstate, Node *node)
 {
-	NestLoop   *expr = (NestLoop *) node;
+	NestLoop *expr = (NestLoop *) node;
 
 	JUMBLE_FIELD(join.plan.parallel_aware);
 	JUMBLE_FIELD(join.plan.parallel_safe);
@@ -3440,7 +3428,7 @@ _jumbleNestLoopParam(JumbleState *jstate, Node *node)
 static void
 _jumbleMergeJoin(JumbleState *jstate, Node *node)
 {
-	MergeJoin  *expr = (MergeJoin *) node;
+	MergeJoin *expr = (MergeJoin *) node;
 
 	JUMBLE_FIELD(join.plan.parallel_aware);
 	JUMBLE_FIELD(join.plan.parallel_safe);
@@ -3464,7 +3452,7 @@ _jumbleMergeJoin(JumbleState *jstate, Node *node)
 static void
 _jumbleHashJoin(JumbleState *jstate, Node *node)
 {
-	HashJoin   *expr = (HashJoin *) node;
+	HashJoin *expr = (HashJoin *) node;
 
 	JUMBLE_FIELD(join.plan.parallel_aware);
 	JUMBLE_FIELD(join.plan.parallel_safe);
@@ -3486,7 +3474,7 @@ _jumbleHashJoin(JumbleState *jstate, Node *node)
 static void
 _jumbleMaterial(JumbleState *jstate, Node *node)
 {
-	Material   *expr = (Material *) node;
+	Material *expr = (Material *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3501,7 +3489,7 @@ _jumbleMaterial(JumbleState *jstate, Node *node)
 static void
 _jumbleMemoize(JumbleState *jstate, Node *node)
 {
-	Memoize    *expr = (Memoize *) node;
+	Memoize *expr = (Memoize *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3523,7 +3511,7 @@ _jumbleMemoize(JumbleState *jstate, Node *node)
 static void
 _jumbleSort(JumbleState *jstate, Node *node)
 {
-	Sort	   *expr = (Sort *) node;
+	Sort *expr = (Sort *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3564,7 +3552,7 @@ _jumbleIncrementalSort(JumbleState *jstate, Node *node)
 static void
 _jumbleGroup(JumbleState *jstate, Node *node)
 {
-	Group	   *expr = (Group *) node;
+	Group *expr = (Group *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3583,7 +3571,7 @@ _jumbleGroup(JumbleState *jstate, Node *node)
 static void
 _jumbleAgg(JumbleState *jstate, Node *node)
 {
-	Agg		   *expr = (Agg *) node;
+	Agg *expr = (Agg *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3608,7 +3596,7 @@ _jumbleAgg(JumbleState *jstate, Node *node)
 static void
 _jumbleWindowAgg(JumbleState *jstate, Node *node)
 {
-	WindowAgg  *expr = (WindowAgg *) node;
+	WindowAgg *expr = (WindowAgg *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3618,7 +3606,6 @@ _jumbleWindowAgg(JumbleState *jstate, Node *node)
 	JUMBLE_NODE(plan.qual);
 	JUMBLE_BITMAPSET(plan.extParam);
 	JUMBLE_BITMAPSET(plan.allParam);
-	JUMBLE_STRING(winname);
 	JUMBLE_FIELD(winref);
 	JUMBLE_FIELD(partNumCols);
 	JUMBLE_ARRAY(partColIdx, expr->partNumCols);
@@ -3644,7 +3631,7 @@ _jumbleWindowAgg(JumbleState *jstate, Node *node)
 static void
 _jumbleUnique(JumbleState *jstate, Node *node)
 {
-	Unique	   *expr = (Unique *) node;
+	Unique *expr = (Unique *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3663,7 +3650,7 @@ _jumbleUnique(JumbleState *jstate, Node *node)
 static void
 _jumbleGather(JumbleState *jstate, Node *node)
 {
-	Gather	   *expr = (Gather *) node;
+	Gather *expr = (Gather *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3706,7 +3693,7 @@ _jumbleGatherMerge(JumbleState *jstate, Node *node)
 static void
 _jumbleHash(JumbleState *jstate, Node *node)
 {
-	Hash	   *expr = (Hash *) node;
+	Hash *expr = (Hash *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3725,7 +3712,7 @@ _jumbleHash(JumbleState *jstate, Node *node)
 static void
 _jumbleSetOp(JumbleState *jstate, Node *node)
 {
-	SetOp	   *expr = (SetOp *) node;
+	SetOp *expr = (SetOp *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3747,7 +3734,7 @@ _jumbleSetOp(JumbleState *jstate, Node *node)
 static void
 _jumbleLockRows(JumbleState *jstate, Node *node)
 {
-	LockRows   *expr = (LockRows *) node;
+	LockRows *expr = (LockRows *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3764,7 +3751,7 @@ _jumbleLockRows(JumbleState *jstate, Node *node)
 static void
 _jumbleLimit(JumbleState *jstate, Node *node)
 {
-	Limit	   *expr = (Limit *) node;
+	Limit *expr = (Limit *) node;
 
 	JUMBLE_FIELD(plan.parallel_aware);
 	JUMBLE_FIELD(plan.parallel_safe);
@@ -3794,7 +3781,7 @@ _jumbleExtensibleNode(JumbleState *jstate, Node *node)
 static void
 _jumbleInteger(JumbleState *jstate, Node *node)
 {
-	Integer    *expr = (Integer *) node;
+	Integer *expr = (Integer *) node;
 
 	JUMBLE_FIELD(ival);
 }
@@ -3802,7 +3789,7 @@ _jumbleInteger(JumbleState *jstate, Node *node)
 static void
 _jumbleFloat(JumbleState *jstate, Node *node)
 {
-	Float	   *expr = (Float *) node;
+	Float *expr = (Float *) node;
 
 	JUMBLE_STRING(fval);
 }
@@ -3810,7 +3797,7 @@ _jumbleFloat(JumbleState *jstate, Node *node)
 static void
 _jumbleBoolean(JumbleState *jstate, Node *node)
 {
-	Boolean    *expr = (Boolean *) node;
+	Boolean *expr = (Boolean *) node;
 
 	JUMBLE_FIELD(boolval);
 }
@@ -3818,7 +3805,7 @@ _jumbleBoolean(JumbleState *jstate, Node *node)
 static void
 _jumbleString(JumbleState *jstate, Node *node)
 {
-	String	   *expr = (String *) node;
+	String *expr = (String *) node;
 
 	JUMBLE_STRING(sval);
 }
@@ -3826,7 +3813,7 @@ _jumbleString(JumbleState *jstate, Node *node)
 static void
 _jumbleBitString(JumbleState *jstate, Node *node)
 {
-	BitString  *expr = (BitString *) node;
+	BitString *expr = (BitString *) node;
 
 	JUMBLE_STRING(bsval);
 }

--- a/pg18_jumblefuncs.switch.c
+++ b/pg18_jumblefuncs.switch.c
@@ -15,933 +15,933 @@
  *
  *-------------------------------------------------------------------------
  */
-case T_Alias:
-_jumbleAlias(jstate, expr);
-break;
-case T_RangeVar:
-_jumbleRangeVar(jstate, expr);
-break;
-case T_TableFunc:
-_jumbleTableFunc(jstate, expr);
-break;
-case T_IntoClause:
-_jumbleIntoClause(jstate, expr);
-break;
-case T_Var:
-_jumbleVar(jstate, expr);
-break;
-case T_Const:
-_jumbleConst(jstate, expr);
-break;
-case T_Param:
-_jumbleParam(jstate, expr);
-break;
-case T_Aggref:
-_jumbleAggref(jstate, expr);
-break;
-case T_GroupingFunc:
-_jumbleGroupingFunc(jstate, expr);
-break;
-case T_WindowFunc:
-_jumbleWindowFunc(jstate, expr);
-break;
-case T_WindowFuncRunCondition:
-_jumbleWindowFuncRunCondition(jstate, expr);
-break;
-case T_MergeSupportFunc:
-_jumbleMergeSupportFunc(jstate, expr);
-break;
-case T_SubscriptingRef:
-_jumbleSubscriptingRef(jstate, expr);
-break;
-case T_FuncExpr:
-_jumbleFuncExpr(jstate, expr);
-break;
-case T_NamedArgExpr:
-_jumbleNamedArgExpr(jstate, expr);
-break;
-case T_OpExpr:
-_jumbleOpExpr(jstate, expr);
-break;
-case T_DistinctExpr:
-_jumbleDistinctExpr(jstate, expr);
-break;
-case T_NullIfExpr:
-_jumbleNullIfExpr(jstate, expr);
-break;
-case T_ScalarArrayOpExpr:
-_jumbleScalarArrayOpExpr(jstate, expr);
-break;
-case T_BoolExpr:
-_jumbleBoolExpr(jstate, expr);
-break;
-case T_SubLink:
-_jumbleSubLink(jstate, expr);
-break;
-case T_SubPlan:
-_jumbleSubPlan(jstate, expr);
-break;
-case T_FieldSelect:
-_jumbleFieldSelect(jstate, expr);
-break;
-case T_FieldStore:
-_jumbleFieldStore(jstate, expr);
-break;
-case T_RelabelType:
-_jumbleRelabelType(jstate, expr);
-break;
-case T_CoerceViaIO:
-_jumbleCoerceViaIO(jstate, expr);
-break;
-case T_ArrayCoerceExpr:
-_jumbleArrayCoerceExpr(jstate, expr);
-break;
-case T_ConvertRowtypeExpr:
-_jumbleConvertRowtypeExpr(jstate, expr);
-break;
-case T_CollateExpr:
-_jumbleCollateExpr(jstate, expr);
-break;
-case T_CaseExpr:
-_jumbleCaseExpr(jstate, expr);
-break;
-case T_CaseWhen:
-_jumbleCaseWhen(jstate, expr);
-break;
-case T_CaseTestExpr:
-_jumbleCaseTestExpr(jstate, expr);
-break;
-case T_ArrayExpr:
-_jumbleArrayExpr(jstate, expr);
-break;
-case T_RowExpr:
-_jumbleRowExpr(jstate, expr);
-break;
-case T_RowCompareExpr:
-_jumbleRowCompareExpr(jstate, expr);
-break;
-case T_CoalesceExpr:
-_jumbleCoalesceExpr(jstate, expr);
-break;
-case T_MinMaxExpr:
-_jumbleMinMaxExpr(jstate, expr);
-break;
-case T_SQLValueFunction:
-_jumbleSQLValueFunction(jstate, expr);
-break;
-case T_XmlExpr:
-_jumbleXmlExpr(jstate, expr);
-break;
-case T_JsonFormat:
-_jumbleJsonFormat(jstate, expr);
-break;
-case T_JsonReturning:
-_jumbleJsonReturning(jstate, expr);
-break;
-case T_JsonValueExpr:
-_jumbleJsonValueExpr(jstate, expr);
-break;
-case T_JsonConstructorExpr:
-_jumbleJsonConstructorExpr(jstate, expr);
-break;
-case T_JsonIsPredicate:
-_jumbleJsonIsPredicate(jstate, expr);
-break;
-case T_JsonBehavior:
-_jumbleJsonBehavior(jstate, expr);
-break;
-case T_JsonExpr:
-_jumbleJsonExpr(jstate, expr);
-break;
-case T_JsonTablePath:
-_jumbleJsonTablePath(jstate, expr);
-break;
-case T_JsonTablePathScan:
-_jumbleJsonTablePathScan(jstate, expr);
-break;
-case T_JsonTableSiblingJoin:
-_jumbleJsonTableSiblingJoin(jstate, expr);
-break;
-case T_NullTest:
-_jumbleNullTest(jstate, expr);
-break;
-case T_BooleanTest:
-_jumbleBooleanTest(jstate, expr);
-break;
-case T_MergeAction:
-_jumbleMergeAction(jstate, expr);
-break;
-case T_CoerceToDomain:
-_jumbleCoerceToDomain(jstate, expr);
-break;
-case T_CoerceToDomainValue:
-_jumbleCoerceToDomainValue(jstate, expr);
-break;
-case T_SetToDefault:
-_jumbleSetToDefault(jstate, expr);
-break;
-case T_CurrentOfExpr:
-_jumbleCurrentOfExpr(jstate, expr);
-break;
-case T_NextValueExpr:
-_jumbleNextValueExpr(jstate, expr);
-break;
-case T_InferenceElem:
-_jumbleInferenceElem(jstate, expr);
-break;
-case T_ReturningExpr:
-_jumbleReturningExpr(jstate, expr);
-break;
-case T_TargetEntry:
-_jumbleTargetEntry(jstate, expr);
-break;
-case T_RangeTblRef:
-_jumbleRangeTblRef(jstate, expr);
-break;
-case T_JoinExpr:
-_jumbleJoinExpr(jstate, expr);
-break;
-case T_FromExpr:
-_jumbleFromExpr(jstate, expr);
-break;
-case T_OnConflictExpr:
-_jumbleOnConflictExpr(jstate, expr);
-break;
-case T_Query:
-_jumbleQuery(jstate, expr);
-break;
-case T_TypeName:
-_jumbleTypeName(jstate, expr);
-break;
-case T_ColumnRef:
-_jumbleColumnRef(jstate, expr);
-break;
-case T_ParamRef:
-_jumbleParamRef(jstate, expr);
-break;
-case T_A_Expr:
-_jumbleA_Expr(jstate, expr);
-break;
-case T_A_Const:
-_jumbleA_Const(jstate, expr);
-break;
-case T_TypeCast:
-_jumbleTypeCast(jstate, expr);
-break;
-case T_CollateClause:
-_jumbleCollateClause(jstate, expr);
-break;
-case T_RoleSpec:
-_jumbleRoleSpec(jstate, expr);
-break;
-case T_FuncCall:
-_jumbleFuncCall(jstate, expr);
-break;
-case T_A_Star:
-_jumbleA_Star(jstate, expr);
-break;
-case T_A_Indices:
-_jumbleA_Indices(jstate, expr);
-break;
-case T_A_Indirection:
-_jumbleA_Indirection(jstate, expr);
-break;
-case T_A_ArrayExpr:
-_jumbleA_ArrayExpr(jstate, expr);
-break;
-case T_ResTarget:
-_jumbleResTarget(jstate, expr);
-break;
-case T_MultiAssignRef:
-_jumbleMultiAssignRef(jstate, expr);
-break;
-case T_SortBy:
-_jumbleSortBy(jstate, expr);
-break;
-case T_WindowDef:
-_jumbleWindowDef(jstate, expr);
-break;
-case T_RangeSubselect:
-_jumbleRangeSubselect(jstate, expr);
-break;
-case T_RangeFunction:
-_jumbleRangeFunction(jstate, expr);
-break;
-case T_RangeTableFunc:
-_jumbleRangeTableFunc(jstate, expr);
-break;
-case T_RangeTableFuncCol:
-_jumbleRangeTableFuncCol(jstate, expr);
-break;
-case T_RangeTableSample:
-_jumbleRangeTableSample(jstate, expr);
-break;
-case T_ColumnDef:
-_jumbleColumnDef(jstate, expr);
-break;
-case T_TableLikeClause:
-_jumbleTableLikeClause(jstate, expr);
-break;
-case T_IndexElem:
-_jumbleIndexElem(jstate, expr);
-break;
-case T_DefElem:
-_jumbleDefElem(jstate, expr);
-break;
-case T_LockingClause:
-_jumbleLockingClause(jstate, expr);
-break;
-case T_XmlSerialize:
-_jumbleXmlSerialize(jstate, expr);
-break;
-case T_PartitionElem:
-_jumblePartitionElem(jstate, expr);
-break;
-case T_PartitionSpec:
-_jumblePartitionSpec(jstate, expr);
-break;
-case T_PartitionBoundSpec:
-_jumblePartitionBoundSpec(jstate, expr);
-break;
-case T_PartitionRangeDatum:
-_jumblePartitionRangeDatum(jstate, expr);
-break;
-case T_PartitionCmd:
-_jumblePartitionCmd(jstate, expr);
-break;
-case T_RangeTblEntry:
-_jumbleRangeTblEntry(jstate, expr);
-break;
-case T_RTEPermissionInfo:
-_jumbleRTEPermissionInfo(jstate, expr);
-break;
-case T_RangeTblFunction:
-_jumbleRangeTblFunction(jstate, expr);
-break;
-case T_TableSampleClause:
-_jumbleTableSampleClause(jstate, expr);
-break;
-case T_WithCheckOption:
-_jumbleWithCheckOption(jstate, expr);
-break;
-case T_SortGroupClause:
-_jumbleSortGroupClause(jstate, expr);
-break;
-case T_GroupingSet:
-_jumbleGroupingSet(jstate, expr);
-break;
-case T_WindowClause:
-_jumbleWindowClause(jstate, expr);
-break;
-case T_RowMarkClause:
-_jumbleRowMarkClause(jstate, expr);
-break;
-case T_WithClause:
-_jumbleWithClause(jstate, expr);
-break;
-case T_InferClause:
-_jumbleInferClause(jstate, expr);
-break;
-case T_OnConflictClause:
-_jumbleOnConflictClause(jstate, expr);
-break;
-case T_CTESearchClause:
-_jumbleCTESearchClause(jstate, expr);
-break;
-case T_CTECycleClause:
-_jumbleCTECycleClause(jstate, expr);
-break;
-case T_CommonTableExpr:
-_jumbleCommonTableExpr(jstate, expr);
-break;
-case T_MergeWhenClause:
-_jumbleMergeWhenClause(jstate, expr);
-break;
-case T_ReturningOption:
-_jumbleReturningOption(jstate, expr);
-break;
-case T_ReturningClause:
-_jumbleReturningClause(jstate, expr);
-break;
-case T_TriggerTransition:
-_jumbleTriggerTransition(jstate, expr);
-break;
-case T_JsonOutput:
-_jumbleJsonOutput(jstate, expr);
-break;
-case T_JsonArgument:
-_jumbleJsonArgument(jstate, expr);
-break;
-case T_JsonFuncExpr:
-_jumbleJsonFuncExpr(jstate, expr);
-break;
-case T_JsonTablePathSpec:
-_jumbleJsonTablePathSpec(jstate, expr);
-break;
-case T_JsonTable:
-_jumbleJsonTable(jstate, expr);
-break;
-case T_JsonTableColumn:
-_jumbleJsonTableColumn(jstate, expr);
-break;
-case T_JsonKeyValue:
-_jumbleJsonKeyValue(jstate, expr);
-break;
-case T_JsonParseExpr:
-_jumbleJsonParseExpr(jstate, expr);
-break;
-case T_JsonScalarExpr:
-_jumbleJsonScalarExpr(jstate, expr);
-break;
-case T_JsonSerializeExpr:
-_jumbleJsonSerializeExpr(jstate, expr);
-break;
-case T_JsonObjectConstructor:
-_jumbleJsonObjectConstructor(jstate, expr);
-break;
-case T_JsonArrayConstructor:
-_jumbleJsonArrayConstructor(jstate, expr);
-break;
-case T_JsonArrayQueryConstructor:
-_jumbleJsonArrayQueryConstructor(jstate, expr);
-break;
-case T_JsonAggConstructor:
-_jumbleJsonAggConstructor(jstate, expr);
-break;
-case T_JsonObjectAgg:
-_jumbleJsonObjectAgg(jstate, expr);
-break;
-case T_JsonArrayAgg:
-_jumbleJsonArrayAgg(jstate, expr);
-break;
-case T_InsertStmt:
-_jumbleInsertStmt(jstate, expr);
-break;
-case T_DeleteStmt:
-_jumbleDeleteStmt(jstate, expr);
-break;
-case T_UpdateStmt:
-_jumbleUpdateStmt(jstate, expr);
-break;
-case T_MergeStmt:
-_jumbleMergeStmt(jstate, expr);
-break;
-case T_SelectStmt:
-_jumbleSelectStmt(jstate, expr);
-break;
-case T_SetOperationStmt:
-_jumbleSetOperationStmt(jstate, expr);
-break;
-case T_ReturnStmt:
-_jumbleReturnStmt(jstate, expr);
-break;
-case T_PLAssignStmt:
-_jumblePLAssignStmt(jstate, expr);
-break;
-case T_CreateSchemaStmt:
-_jumbleCreateSchemaStmt(jstate, expr);
-break;
-case T_AlterTableStmt:
-_jumbleAlterTableStmt(jstate, expr);
-break;
-case T_AlterTableCmd:
-_jumbleAlterTableCmd(jstate, expr);
-break;
-case T_ATAlterConstraint:
-_jumbleATAlterConstraint(jstate, expr);
-break;
-case T_ReplicaIdentityStmt:
-_jumbleReplicaIdentityStmt(jstate, expr);
-break;
-case T_AlterCollationStmt:
-_jumbleAlterCollationStmt(jstate, expr);
-break;
-case T_AlterDomainStmt:
-_jumbleAlterDomainStmt(jstate, expr);
-break;
-case T_GrantStmt:
-_jumbleGrantStmt(jstate, expr);
-break;
-case T_ObjectWithArgs:
-_jumbleObjectWithArgs(jstate, expr);
-break;
-case T_AccessPriv:
-_jumbleAccessPriv(jstate, expr);
-break;
-case T_GrantRoleStmt:
-_jumbleGrantRoleStmt(jstate, expr);
-break;
-case T_AlterDefaultPrivilegesStmt:
-_jumbleAlterDefaultPrivilegesStmt(jstate, expr);
-break;
-case T_CopyStmt:
-_jumbleCopyStmt(jstate, expr);
-break;
-case T_VariableSetStmt:
-_jumbleVariableSetStmt(jstate, expr);
-break;
-case T_VariableShowStmt:
-_jumbleVariableShowStmt(jstate, expr);
-break;
-case T_CreateStmt:
-_jumbleCreateStmt(jstate, expr);
-break;
-case T_Constraint:
-_jumbleConstraint(jstate, expr);
-break;
-case T_CreateTableSpaceStmt:
-_jumbleCreateTableSpaceStmt(jstate, expr);
-break;
-case T_DropTableSpaceStmt:
-_jumbleDropTableSpaceStmt(jstate, expr);
-break;
-case T_AlterTableSpaceOptionsStmt:
-_jumbleAlterTableSpaceOptionsStmt(jstate, expr);
-break;
-case T_AlterTableMoveAllStmt:
-_jumbleAlterTableMoveAllStmt(jstate, expr);
-break;
-case T_CreateExtensionStmt:
-_jumbleCreateExtensionStmt(jstate, expr);
-break;
-case T_AlterExtensionStmt:
-_jumbleAlterExtensionStmt(jstate, expr);
-break;
-case T_AlterExtensionContentsStmt:
-_jumbleAlterExtensionContentsStmt(jstate, expr);
-break;
-case T_CreateFdwStmt:
-_jumbleCreateFdwStmt(jstate, expr);
-break;
-case T_AlterFdwStmt:
-_jumbleAlterFdwStmt(jstate, expr);
-break;
-case T_CreateForeignServerStmt:
-_jumbleCreateForeignServerStmt(jstate, expr);
-break;
-case T_AlterForeignServerStmt:
-_jumbleAlterForeignServerStmt(jstate, expr);
-break;
-case T_CreateForeignTableStmt:
-_jumbleCreateForeignTableStmt(jstate, expr);
-break;
-case T_CreateUserMappingStmt:
-_jumbleCreateUserMappingStmt(jstate, expr);
-break;
-case T_AlterUserMappingStmt:
-_jumbleAlterUserMappingStmt(jstate, expr);
-break;
-case T_DropUserMappingStmt:
-_jumbleDropUserMappingStmt(jstate, expr);
-break;
-case T_ImportForeignSchemaStmt:
-_jumbleImportForeignSchemaStmt(jstate, expr);
-break;
-case T_CreatePolicyStmt:
-_jumbleCreatePolicyStmt(jstate, expr);
-break;
-case T_AlterPolicyStmt:
-_jumbleAlterPolicyStmt(jstate, expr);
-break;
-case T_CreateAmStmt:
-_jumbleCreateAmStmt(jstate, expr);
-break;
-case T_CreateTrigStmt:
-_jumbleCreateTrigStmt(jstate, expr);
-break;
-case T_CreateEventTrigStmt:
-_jumbleCreateEventTrigStmt(jstate, expr);
-break;
-case T_AlterEventTrigStmt:
-_jumbleAlterEventTrigStmt(jstate, expr);
-break;
-case T_CreatePLangStmt:
-_jumbleCreatePLangStmt(jstate, expr);
-break;
-case T_CreateRoleStmt:
-_jumbleCreateRoleStmt(jstate, expr);
-break;
-case T_AlterRoleStmt:
-_jumbleAlterRoleStmt(jstate, expr);
-break;
-case T_AlterRoleSetStmt:
-_jumbleAlterRoleSetStmt(jstate, expr);
-break;
-case T_DropRoleStmt:
-_jumbleDropRoleStmt(jstate, expr);
-break;
-case T_CreateSeqStmt:
-_jumbleCreateSeqStmt(jstate, expr);
-break;
-case T_AlterSeqStmt:
-_jumbleAlterSeqStmt(jstate, expr);
-break;
-case T_DefineStmt:
-_jumbleDefineStmt(jstate, expr);
-break;
-case T_CreateDomainStmt:
-_jumbleCreateDomainStmt(jstate, expr);
-break;
-case T_CreateOpClassStmt:
-_jumbleCreateOpClassStmt(jstate, expr);
-break;
-case T_CreateOpClassItem:
-_jumbleCreateOpClassItem(jstate, expr);
-break;
-case T_CreateOpFamilyStmt:
-_jumbleCreateOpFamilyStmt(jstate, expr);
-break;
-case T_AlterOpFamilyStmt:
-_jumbleAlterOpFamilyStmt(jstate, expr);
-break;
-case T_DropStmt:
-_jumbleDropStmt(jstate, expr);
-break;
-case T_TruncateStmt:
-_jumbleTruncateStmt(jstate, expr);
-break;
-case T_CommentStmt:
-_jumbleCommentStmt(jstate, expr);
-break;
-case T_SecLabelStmt:
-_jumbleSecLabelStmt(jstate, expr);
-break;
-case T_DeclareCursorStmt:
-_jumbleDeclareCursorStmt(jstate, expr);
-break;
-case T_ClosePortalStmt:
-_jumbleClosePortalStmt(jstate, expr);
-break;
-case T_FetchStmt:
-_jumbleFetchStmt(jstate, expr);
-break;
-case T_IndexStmt:
-_jumbleIndexStmt(jstate, expr);
-break;
-case T_CreateStatsStmt:
-_jumbleCreateStatsStmt(jstate, expr);
-break;
-case T_StatsElem:
-_jumbleStatsElem(jstate, expr);
-break;
-case T_AlterStatsStmt:
-_jumbleAlterStatsStmt(jstate, expr);
-break;
-case T_CreateFunctionStmt:
-_jumbleCreateFunctionStmt(jstate, expr);
-break;
-case T_FunctionParameter:
-_jumbleFunctionParameter(jstate, expr);
-break;
-case T_AlterFunctionStmt:
-_jumbleAlterFunctionStmt(jstate, expr);
-break;
-case T_DoStmt:
-_jumbleDoStmt(jstate, expr);
-break;
-case T_CallStmt:
-_jumbleCallStmt(jstate, expr);
-break;
-case T_RenameStmt:
-_jumbleRenameStmt(jstate, expr);
-break;
-case T_AlterObjectDependsStmt:
-_jumbleAlterObjectDependsStmt(jstate, expr);
-break;
-case T_AlterObjectSchemaStmt:
-_jumbleAlterObjectSchemaStmt(jstate, expr);
-break;
-case T_AlterOwnerStmt:
-_jumbleAlterOwnerStmt(jstate, expr);
-break;
-case T_AlterOperatorStmt:
-_jumbleAlterOperatorStmt(jstate, expr);
-break;
-case T_AlterTypeStmt:
-_jumbleAlterTypeStmt(jstate, expr);
-break;
-case T_RuleStmt:
-_jumbleRuleStmt(jstate, expr);
-break;
-case T_NotifyStmt:
-_jumbleNotifyStmt(jstate, expr);
-break;
-case T_ListenStmt:
-_jumbleListenStmt(jstate, expr);
-break;
-case T_UnlistenStmt:
-_jumbleUnlistenStmt(jstate, expr);
-break;
-case T_TransactionStmt:
-_jumbleTransactionStmt(jstate, expr);
-break;
-case T_CompositeTypeStmt:
-_jumbleCompositeTypeStmt(jstate, expr);
-break;
-case T_CreateEnumStmt:
-_jumbleCreateEnumStmt(jstate, expr);
-break;
-case T_CreateRangeStmt:
-_jumbleCreateRangeStmt(jstate, expr);
-break;
-case T_AlterEnumStmt:
-_jumbleAlterEnumStmt(jstate, expr);
-break;
-case T_ViewStmt:
-_jumbleViewStmt(jstate, expr);
-break;
-case T_LoadStmt:
-_jumbleLoadStmt(jstate, expr);
-break;
-case T_CreatedbStmt:
-_jumbleCreatedbStmt(jstate, expr);
-break;
-case T_AlterDatabaseStmt:
-_jumbleAlterDatabaseStmt(jstate, expr);
-break;
-case T_AlterDatabaseRefreshCollStmt:
-_jumbleAlterDatabaseRefreshCollStmt(jstate, expr);
-break;
-case T_AlterDatabaseSetStmt:
-_jumbleAlterDatabaseSetStmt(jstate, expr);
-break;
-case T_DropdbStmt:
-_jumbleDropdbStmt(jstate, expr);
-break;
-case T_AlterSystemStmt:
-_jumbleAlterSystemStmt(jstate, expr);
-break;
-case T_ClusterStmt:
-_jumbleClusterStmt(jstate, expr);
-break;
-case T_VacuumStmt:
-_jumbleVacuumStmt(jstate, expr);
-break;
-case T_VacuumRelation:
-_jumbleVacuumRelation(jstate, expr);
-break;
-case T_ExplainStmt:
-_jumbleExplainStmt(jstate, expr);
-break;
-case T_CreateTableAsStmt:
-_jumbleCreateTableAsStmt(jstate, expr);
-break;
-case T_RefreshMatViewStmt:
-_jumbleRefreshMatViewStmt(jstate, expr);
-break;
-case T_CheckPointStmt:
-_jumbleCheckPointStmt(jstate, expr);
-break;
-case T_DiscardStmt:
-_jumbleDiscardStmt(jstate, expr);
-break;
-case T_LockStmt:
-_jumbleLockStmt(jstate, expr);
-break;
-case T_ConstraintsSetStmt:
-_jumbleConstraintsSetStmt(jstate, expr);
-break;
-case T_ReindexStmt:
-_jumbleReindexStmt(jstate, expr);
-break;
-case T_CreateConversionStmt:
-_jumbleCreateConversionStmt(jstate, expr);
-break;
-case T_CreateCastStmt:
-_jumbleCreateCastStmt(jstate, expr);
-break;
-case T_CreateTransformStmt:
-_jumbleCreateTransformStmt(jstate, expr);
-break;
-case T_PrepareStmt:
-_jumblePrepareStmt(jstate, expr);
-break;
-case T_ExecuteStmt:
-_jumbleExecuteStmt(jstate, expr);
-break;
-case T_DeallocateStmt:
-_jumbleDeallocateStmt(jstate, expr);
-break;
-case T_DropOwnedStmt:
-_jumbleDropOwnedStmt(jstate, expr);
-break;
-case T_ReassignOwnedStmt:
-_jumbleReassignOwnedStmt(jstate, expr);
-break;
-case T_AlterTSDictionaryStmt:
-_jumbleAlterTSDictionaryStmt(jstate, expr);
-break;
-case T_AlterTSConfigurationStmt:
-_jumbleAlterTSConfigurationStmt(jstate, expr);
-break;
-case T_PublicationTable:
-_jumblePublicationTable(jstate, expr);
-break;
-case T_PublicationObjSpec:
-_jumblePublicationObjSpec(jstate, expr);
-break;
-case T_CreatePublicationStmt:
-_jumbleCreatePublicationStmt(jstate, expr);
-break;
-case T_AlterPublicationStmt:
-_jumbleAlterPublicationStmt(jstate, expr);
-break;
-case T_CreateSubscriptionStmt:
-_jumbleCreateSubscriptionStmt(jstate, expr);
-break;
-case T_AlterSubscriptionStmt:
-_jumbleAlterSubscriptionStmt(jstate, expr);
-break;
-case T_DropSubscriptionStmt:
-_jumbleDropSubscriptionStmt(jstate, expr);
-break;
-case T_GroupByOrdering:
-_jumbleGroupByOrdering(jstate, expr);
-break;
-case T_Result:
-_jumbleResult(jstate, expr);
-break;
-case T_ProjectSet:
-_jumbleProjectSet(jstate, expr);
-break;
-case T_ModifyTable:
-_jumbleModifyTable(jstate, expr);
-break;
-case T_Append:
-_jumbleAppend(jstate, expr);
-break;
-case T_MergeAppend:
-_jumbleMergeAppend(jstate, expr);
-break;
-case T_RecursiveUnion:
-_jumbleRecursiveUnion(jstate, expr);
-break;
-case T_BitmapAnd:
-_jumbleBitmapAnd(jstate, expr);
-break;
-case T_BitmapOr:
-_jumbleBitmapOr(jstate, expr);
-break;
-case T_SeqScan:
-_jumbleSeqScan(jstate, expr);
-break;
-case T_SampleScan:
-_jumbleSampleScan(jstate, expr);
-break;
-case T_IndexScan:
-_jumbleIndexScan(jstate, expr);
-break;
-case T_IndexOnlyScan:
-_jumbleIndexOnlyScan(jstate, expr);
-break;
-case T_BitmapIndexScan:
-_jumbleBitmapIndexScan(jstate, expr);
-break;
-case T_BitmapHeapScan:
-_jumbleBitmapHeapScan(jstate, expr);
-break;
-case T_TidScan:
-_jumbleTidScan(jstate, expr);
-break;
-case T_TidRangeScan:
-_jumbleTidRangeScan(jstate, expr);
-break;
-case T_SubqueryScan:
-_jumbleSubqueryScan(jstate, expr);
-break;
-case T_FunctionScan:
-_jumbleFunctionScan(jstate, expr);
-break;
-case T_ValuesScan:
-_jumbleValuesScan(jstate, expr);
-break;
-case T_TableFuncScan:
-_jumbleTableFuncScan(jstate, expr);
-break;
-case T_CteScan:
-_jumbleCteScan(jstate, expr);
-break;
-case T_NamedTuplestoreScan:
-_jumbleNamedTuplestoreScan(jstate, expr);
-break;
-case T_WorkTableScan:
-_jumbleWorkTableScan(jstate, expr);
-break;
-case T_ForeignScan:
-_jumbleForeignScan(jstate, expr);
-break;
-case T_CustomScan:
-_jumbleCustomScan(jstate, expr);
-break;
-case T_NestLoop:
-_jumbleNestLoop(jstate, expr);
-break;
-case T_NestLoopParam:
-_jumbleNestLoopParam(jstate, expr);
-break;
-case T_MergeJoin:
-_jumbleMergeJoin(jstate, expr);
-break;
-case T_HashJoin:
-_jumbleHashJoin(jstate, expr);
-break;
-case T_Material:
-_jumbleMaterial(jstate, expr);
-break;
-case T_Memoize:
-_jumbleMemoize(jstate, expr);
-break;
-case T_Sort:
-_jumbleSort(jstate, expr);
-break;
-case T_IncrementalSort:
-_jumbleIncrementalSort(jstate, expr);
-break;
-case T_Group:
-_jumbleGroup(jstate, expr);
-break;
-case T_Agg:
-_jumbleAgg(jstate, expr);
-break;
-case T_WindowAgg:
-_jumbleWindowAgg(jstate, expr);
-break;
-case T_Unique:
-_jumbleUnique(jstate, expr);
-break;
-case T_Gather:
-_jumbleGather(jstate, expr);
-break;
-case T_GatherMerge:
-_jumbleGatherMerge(jstate, expr);
-break;
-case T_Hash:
-_jumbleHash(jstate, expr);
-break;
-case T_SetOp:
-_jumbleSetOp(jstate, expr);
-break;
-case T_LockRows:
-_jumbleLockRows(jstate, expr);
-break;
-case T_Limit:
-_jumbleLimit(jstate, expr);
-break;
-case T_ExtensibleNode:
-_jumbleExtensibleNode(jstate, expr);
-break;
-case T_Integer:
-_jumbleInteger(jstate, expr);
-break;
-case T_Float:
-_jumbleFloat(jstate, expr);
-break;
-case T_Boolean:
-_jumbleBoolean(jstate, expr);
-break;
-case T_String:
-_jumbleString(jstate, expr);
-break;
-case T_BitString:
-_jumbleBitString(jstate, expr);
-break;
+			case T_Alias:
+				_jumbleAlias(jstate, expr);
+				break;
+			case T_RangeVar:
+				_jumbleRangeVar(jstate, expr);
+				break;
+			case T_TableFunc:
+				_jumbleTableFunc(jstate, expr);
+				break;
+			case T_IntoClause:
+				_jumbleIntoClause(jstate, expr);
+				break;
+			case T_Var:
+				_jumbleVar(jstate, expr);
+				break;
+			case T_Const:
+				_jumbleConst(jstate, expr);
+				break;
+			case T_Param:
+				_jumbleParam(jstate, expr);
+				break;
+			case T_Aggref:
+				_jumbleAggref(jstate, expr);
+				break;
+			case T_GroupingFunc:
+				_jumbleGroupingFunc(jstate, expr);
+				break;
+			case T_WindowFunc:
+				_jumbleWindowFunc(jstate, expr);
+				break;
+			case T_WindowFuncRunCondition:
+				_jumbleWindowFuncRunCondition(jstate, expr);
+				break;
+			case T_MergeSupportFunc:
+				_jumbleMergeSupportFunc(jstate, expr);
+				break;
+			case T_SubscriptingRef:
+				_jumbleSubscriptingRef(jstate, expr);
+				break;
+			case T_FuncExpr:
+				_jumbleFuncExpr(jstate, expr);
+				break;
+			case T_NamedArgExpr:
+				_jumbleNamedArgExpr(jstate, expr);
+				break;
+			case T_OpExpr:
+				_jumbleOpExpr(jstate, expr);
+				break;
+			case T_DistinctExpr:
+				_jumbleDistinctExpr(jstate, expr);
+				break;
+			case T_NullIfExpr:
+				_jumbleNullIfExpr(jstate, expr);
+				break;
+			case T_ScalarArrayOpExpr:
+				_jumbleScalarArrayOpExpr(jstate, expr);
+				break;
+			case T_BoolExpr:
+				_jumbleBoolExpr(jstate, expr);
+				break;
+			case T_SubLink:
+				_jumbleSubLink(jstate, expr);
+				break;
+			case T_SubPlan:
+				_jumbleSubPlan(jstate, expr);
+				break;
+			case T_FieldSelect:
+				_jumbleFieldSelect(jstate, expr);
+				break;
+			case T_FieldStore:
+				_jumbleFieldStore(jstate, expr);
+				break;
+			case T_RelabelType:
+				_jumbleRelabelType(jstate, expr);
+				break;
+			case T_CoerceViaIO:
+				_jumbleCoerceViaIO(jstate, expr);
+				break;
+			case T_ArrayCoerceExpr:
+				_jumbleArrayCoerceExpr(jstate, expr);
+				break;
+			case T_ConvertRowtypeExpr:
+				_jumbleConvertRowtypeExpr(jstate, expr);
+				break;
+			case T_CollateExpr:
+				_jumbleCollateExpr(jstate, expr);
+				break;
+			case T_CaseExpr:
+				_jumbleCaseExpr(jstate, expr);
+				break;
+			case T_CaseWhen:
+				_jumbleCaseWhen(jstate, expr);
+				break;
+			case T_CaseTestExpr:
+				_jumbleCaseTestExpr(jstate, expr);
+				break;
+			case T_ArrayExpr:
+				_jumbleArrayExpr(jstate, expr);
+				break;
+			case T_RowExpr:
+				_jumbleRowExpr(jstate, expr);
+				break;
+			case T_RowCompareExpr:
+				_jumbleRowCompareExpr(jstate, expr);
+				break;
+			case T_CoalesceExpr:
+				_jumbleCoalesceExpr(jstate, expr);
+				break;
+			case T_MinMaxExpr:
+				_jumbleMinMaxExpr(jstate, expr);
+				break;
+			case T_SQLValueFunction:
+				_jumbleSQLValueFunction(jstate, expr);
+				break;
+			case T_XmlExpr:
+				_jumbleXmlExpr(jstate, expr);
+				break;
+			case T_JsonFormat:
+				_jumbleJsonFormat(jstate, expr);
+				break;
+			case T_JsonReturning:
+				_jumbleJsonReturning(jstate, expr);
+				break;
+			case T_JsonValueExpr:
+				_jumbleJsonValueExpr(jstate, expr);
+				break;
+			case T_JsonConstructorExpr:
+				_jumbleJsonConstructorExpr(jstate, expr);
+				break;
+			case T_JsonIsPredicate:
+				_jumbleJsonIsPredicate(jstate, expr);
+				break;
+			case T_JsonBehavior:
+				_jumbleJsonBehavior(jstate, expr);
+				break;
+			case T_JsonExpr:
+				_jumbleJsonExpr(jstate, expr);
+				break;
+			case T_JsonTablePath:
+				_jumbleJsonTablePath(jstate, expr);
+				break;
+			case T_JsonTablePathScan:
+				_jumbleJsonTablePathScan(jstate, expr);
+				break;
+			case T_JsonTableSiblingJoin:
+				_jumbleJsonTableSiblingJoin(jstate, expr);
+				break;
+			case T_NullTest:
+				_jumbleNullTest(jstate, expr);
+				break;
+			case T_BooleanTest:
+				_jumbleBooleanTest(jstate, expr);
+				break;
+			case T_MergeAction:
+				_jumbleMergeAction(jstate, expr);
+				break;
+			case T_CoerceToDomain:
+				_jumbleCoerceToDomain(jstate, expr);
+				break;
+			case T_CoerceToDomainValue:
+				_jumbleCoerceToDomainValue(jstate, expr);
+				break;
+			case T_SetToDefault:
+				_jumbleSetToDefault(jstate, expr);
+				break;
+			case T_CurrentOfExpr:
+				_jumbleCurrentOfExpr(jstate, expr);
+				break;
+			case T_NextValueExpr:
+				_jumbleNextValueExpr(jstate, expr);
+				break;
+			case T_InferenceElem:
+				_jumbleInferenceElem(jstate, expr);
+				break;
+			case T_ReturningExpr:
+				_jumbleReturningExpr(jstate, expr);
+				break;
+			case T_TargetEntry:
+				_jumbleTargetEntry(jstate, expr);
+				break;
+			case T_RangeTblRef:
+				_jumbleRangeTblRef(jstate, expr);
+				break;
+			case T_JoinExpr:
+				_jumbleJoinExpr(jstate, expr);
+				break;
+			case T_FromExpr:
+				_jumbleFromExpr(jstate, expr);
+				break;
+			case T_OnConflictExpr:
+				_jumbleOnConflictExpr(jstate, expr);
+				break;
+			case T_Query:
+				_jumbleQuery(jstate, expr);
+				break;
+			case T_TypeName:
+				_jumbleTypeName(jstate, expr);
+				break;
+			case T_ColumnRef:
+				_jumbleColumnRef(jstate, expr);
+				break;
+			case T_ParamRef:
+				_jumbleParamRef(jstate, expr);
+				break;
+			case T_A_Expr:
+				_jumbleA_Expr(jstate, expr);
+				break;
+			case T_A_Const:
+				_jumbleA_Const(jstate, expr);
+				break;
+			case T_TypeCast:
+				_jumbleTypeCast(jstate, expr);
+				break;
+			case T_CollateClause:
+				_jumbleCollateClause(jstate, expr);
+				break;
+			case T_RoleSpec:
+				_jumbleRoleSpec(jstate, expr);
+				break;
+			case T_FuncCall:
+				_jumbleFuncCall(jstate, expr);
+				break;
+			case T_A_Star:
+				_jumbleA_Star(jstate, expr);
+				break;
+			case T_A_Indices:
+				_jumbleA_Indices(jstate, expr);
+				break;
+			case T_A_Indirection:
+				_jumbleA_Indirection(jstate, expr);
+				break;
+			case T_A_ArrayExpr:
+				_jumbleA_ArrayExpr(jstate, expr);
+				break;
+			case T_ResTarget:
+				_jumbleResTarget(jstate, expr);
+				break;
+			case T_MultiAssignRef:
+				_jumbleMultiAssignRef(jstate, expr);
+				break;
+			case T_SortBy:
+				_jumbleSortBy(jstate, expr);
+				break;
+			case T_WindowDef:
+				_jumbleWindowDef(jstate, expr);
+				break;
+			case T_RangeSubselect:
+				_jumbleRangeSubselect(jstate, expr);
+				break;
+			case T_RangeFunction:
+				_jumbleRangeFunction(jstate, expr);
+				break;
+			case T_RangeTableFunc:
+				_jumbleRangeTableFunc(jstate, expr);
+				break;
+			case T_RangeTableFuncCol:
+				_jumbleRangeTableFuncCol(jstate, expr);
+				break;
+			case T_RangeTableSample:
+				_jumbleRangeTableSample(jstate, expr);
+				break;
+			case T_ColumnDef:
+				_jumbleColumnDef(jstate, expr);
+				break;
+			case T_TableLikeClause:
+				_jumbleTableLikeClause(jstate, expr);
+				break;
+			case T_IndexElem:
+				_jumbleIndexElem(jstate, expr);
+				break;
+			case T_DefElem:
+				_jumbleDefElem(jstate, expr);
+				break;
+			case T_LockingClause:
+				_jumbleLockingClause(jstate, expr);
+				break;
+			case T_XmlSerialize:
+				_jumbleXmlSerialize(jstate, expr);
+				break;
+			case T_PartitionElem:
+				_jumblePartitionElem(jstate, expr);
+				break;
+			case T_PartitionSpec:
+				_jumblePartitionSpec(jstate, expr);
+				break;
+			case T_PartitionBoundSpec:
+				_jumblePartitionBoundSpec(jstate, expr);
+				break;
+			case T_PartitionRangeDatum:
+				_jumblePartitionRangeDatum(jstate, expr);
+				break;
+			case T_PartitionCmd:
+				_jumblePartitionCmd(jstate, expr);
+				break;
+			case T_RangeTblEntry:
+				_jumbleRangeTblEntry(jstate, expr);
+				break;
+			case T_RTEPermissionInfo:
+				_jumbleRTEPermissionInfo(jstate, expr);
+				break;
+			case T_RangeTblFunction:
+				_jumbleRangeTblFunction(jstate, expr);
+				break;
+			case T_TableSampleClause:
+				_jumbleTableSampleClause(jstate, expr);
+				break;
+			case T_WithCheckOption:
+				_jumbleWithCheckOption(jstate, expr);
+				break;
+			case T_SortGroupClause:
+				_jumbleSortGroupClause(jstate, expr);
+				break;
+			case T_GroupingSet:
+				_jumbleGroupingSet(jstate, expr);
+				break;
+			case T_WindowClause:
+				_jumbleWindowClause(jstate, expr);
+				break;
+			case T_RowMarkClause:
+				_jumbleRowMarkClause(jstate, expr);
+				break;
+			case T_WithClause:
+				_jumbleWithClause(jstate, expr);
+				break;
+			case T_InferClause:
+				_jumbleInferClause(jstate, expr);
+				break;
+			case T_OnConflictClause:
+				_jumbleOnConflictClause(jstate, expr);
+				break;
+			case T_CTESearchClause:
+				_jumbleCTESearchClause(jstate, expr);
+				break;
+			case T_CTECycleClause:
+				_jumbleCTECycleClause(jstate, expr);
+				break;
+			case T_CommonTableExpr:
+				_jumbleCommonTableExpr(jstate, expr);
+				break;
+			case T_MergeWhenClause:
+				_jumbleMergeWhenClause(jstate, expr);
+				break;
+			case T_ReturningOption:
+				_jumbleReturningOption(jstate, expr);
+				break;
+			case T_ReturningClause:
+				_jumbleReturningClause(jstate, expr);
+				break;
+			case T_TriggerTransition:
+				_jumbleTriggerTransition(jstate, expr);
+				break;
+			case T_JsonOutput:
+				_jumbleJsonOutput(jstate, expr);
+				break;
+			case T_JsonArgument:
+				_jumbleJsonArgument(jstate, expr);
+				break;
+			case T_JsonFuncExpr:
+				_jumbleJsonFuncExpr(jstate, expr);
+				break;
+			case T_JsonTablePathSpec:
+				_jumbleJsonTablePathSpec(jstate, expr);
+				break;
+			case T_JsonTable:
+				_jumbleJsonTable(jstate, expr);
+				break;
+			case T_JsonTableColumn:
+				_jumbleJsonTableColumn(jstate, expr);
+				break;
+			case T_JsonKeyValue:
+				_jumbleJsonKeyValue(jstate, expr);
+				break;
+			case T_JsonParseExpr:
+				_jumbleJsonParseExpr(jstate, expr);
+				break;
+			case T_JsonScalarExpr:
+				_jumbleJsonScalarExpr(jstate, expr);
+				break;
+			case T_JsonSerializeExpr:
+				_jumbleJsonSerializeExpr(jstate, expr);
+				break;
+			case T_JsonObjectConstructor:
+				_jumbleJsonObjectConstructor(jstate, expr);
+				break;
+			case T_JsonArrayConstructor:
+				_jumbleJsonArrayConstructor(jstate, expr);
+				break;
+			case T_JsonArrayQueryConstructor:
+				_jumbleJsonArrayQueryConstructor(jstate, expr);
+				break;
+			case T_JsonAggConstructor:
+				_jumbleJsonAggConstructor(jstate, expr);
+				break;
+			case T_JsonObjectAgg:
+				_jumbleJsonObjectAgg(jstate, expr);
+				break;
+			case T_JsonArrayAgg:
+				_jumbleJsonArrayAgg(jstate, expr);
+				break;
+			case T_InsertStmt:
+				_jumbleInsertStmt(jstate, expr);
+				break;
+			case T_DeleteStmt:
+				_jumbleDeleteStmt(jstate, expr);
+				break;
+			case T_UpdateStmt:
+				_jumbleUpdateStmt(jstate, expr);
+				break;
+			case T_MergeStmt:
+				_jumbleMergeStmt(jstate, expr);
+				break;
+			case T_SelectStmt:
+				_jumbleSelectStmt(jstate, expr);
+				break;
+			case T_SetOperationStmt:
+				_jumbleSetOperationStmt(jstate, expr);
+				break;
+			case T_ReturnStmt:
+				_jumbleReturnStmt(jstate, expr);
+				break;
+			case T_PLAssignStmt:
+				_jumblePLAssignStmt(jstate, expr);
+				break;
+			case T_CreateSchemaStmt:
+				_jumbleCreateSchemaStmt(jstate, expr);
+				break;
+			case T_AlterTableStmt:
+				_jumbleAlterTableStmt(jstate, expr);
+				break;
+			case T_AlterTableCmd:
+				_jumbleAlterTableCmd(jstate, expr);
+				break;
+			case T_ATAlterConstraint:
+				_jumbleATAlterConstraint(jstate, expr);
+				break;
+			case T_ReplicaIdentityStmt:
+				_jumbleReplicaIdentityStmt(jstate, expr);
+				break;
+			case T_AlterCollationStmt:
+				_jumbleAlterCollationStmt(jstate, expr);
+				break;
+			case T_AlterDomainStmt:
+				_jumbleAlterDomainStmt(jstate, expr);
+				break;
+			case T_GrantStmt:
+				_jumbleGrantStmt(jstate, expr);
+				break;
+			case T_ObjectWithArgs:
+				_jumbleObjectWithArgs(jstate, expr);
+				break;
+			case T_AccessPriv:
+				_jumbleAccessPriv(jstate, expr);
+				break;
+			case T_GrantRoleStmt:
+				_jumbleGrantRoleStmt(jstate, expr);
+				break;
+			case T_AlterDefaultPrivilegesStmt:
+				_jumbleAlterDefaultPrivilegesStmt(jstate, expr);
+				break;
+			case T_CopyStmt:
+				_jumbleCopyStmt(jstate, expr);
+				break;
+			case T_VariableSetStmt:
+				_jumbleVariableSetStmt(jstate, expr);
+				break;
+			case T_VariableShowStmt:
+				_jumbleVariableShowStmt(jstate, expr);
+				break;
+			case T_CreateStmt:
+				_jumbleCreateStmt(jstate, expr);
+				break;
+			case T_Constraint:
+				_jumbleConstraint(jstate, expr);
+				break;
+			case T_CreateTableSpaceStmt:
+				_jumbleCreateTableSpaceStmt(jstate, expr);
+				break;
+			case T_DropTableSpaceStmt:
+				_jumbleDropTableSpaceStmt(jstate, expr);
+				break;
+			case T_AlterTableSpaceOptionsStmt:
+				_jumbleAlterTableSpaceOptionsStmt(jstate, expr);
+				break;
+			case T_AlterTableMoveAllStmt:
+				_jumbleAlterTableMoveAllStmt(jstate, expr);
+				break;
+			case T_CreateExtensionStmt:
+				_jumbleCreateExtensionStmt(jstate, expr);
+				break;
+			case T_AlterExtensionStmt:
+				_jumbleAlterExtensionStmt(jstate, expr);
+				break;
+			case T_AlterExtensionContentsStmt:
+				_jumbleAlterExtensionContentsStmt(jstate, expr);
+				break;
+			case T_CreateFdwStmt:
+				_jumbleCreateFdwStmt(jstate, expr);
+				break;
+			case T_AlterFdwStmt:
+				_jumbleAlterFdwStmt(jstate, expr);
+				break;
+			case T_CreateForeignServerStmt:
+				_jumbleCreateForeignServerStmt(jstate, expr);
+				break;
+			case T_AlterForeignServerStmt:
+				_jumbleAlterForeignServerStmt(jstate, expr);
+				break;
+			case T_CreateForeignTableStmt:
+				_jumbleCreateForeignTableStmt(jstate, expr);
+				break;
+			case T_CreateUserMappingStmt:
+				_jumbleCreateUserMappingStmt(jstate, expr);
+				break;
+			case T_AlterUserMappingStmt:
+				_jumbleAlterUserMappingStmt(jstate, expr);
+				break;
+			case T_DropUserMappingStmt:
+				_jumbleDropUserMappingStmt(jstate, expr);
+				break;
+			case T_ImportForeignSchemaStmt:
+				_jumbleImportForeignSchemaStmt(jstate, expr);
+				break;
+			case T_CreatePolicyStmt:
+				_jumbleCreatePolicyStmt(jstate, expr);
+				break;
+			case T_AlterPolicyStmt:
+				_jumbleAlterPolicyStmt(jstate, expr);
+				break;
+			case T_CreateAmStmt:
+				_jumbleCreateAmStmt(jstate, expr);
+				break;
+			case T_CreateTrigStmt:
+				_jumbleCreateTrigStmt(jstate, expr);
+				break;
+			case T_CreateEventTrigStmt:
+				_jumbleCreateEventTrigStmt(jstate, expr);
+				break;
+			case T_AlterEventTrigStmt:
+				_jumbleAlterEventTrigStmt(jstate, expr);
+				break;
+			case T_CreatePLangStmt:
+				_jumbleCreatePLangStmt(jstate, expr);
+				break;
+			case T_CreateRoleStmt:
+				_jumbleCreateRoleStmt(jstate, expr);
+				break;
+			case T_AlterRoleStmt:
+				_jumbleAlterRoleStmt(jstate, expr);
+				break;
+			case T_AlterRoleSetStmt:
+				_jumbleAlterRoleSetStmt(jstate, expr);
+				break;
+			case T_DropRoleStmt:
+				_jumbleDropRoleStmt(jstate, expr);
+				break;
+			case T_CreateSeqStmt:
+				_jumbleCreateSeqStmt(jstate, expr);
+				break;
+			case T_AlterSeqStmt:
+				_jumbleAlterSeqStmt(jstate, expr);
+				break;
+			case T_DefineStmt:
+				_jumbleDefineStmt(jstate, expr);
+				break;
+			case T_CreateDomainStmt:
+				_jumbleCreateDomainStmt(jstate, expr);
+				break;
+			case T_CreateOpClassStmt:
+				_jumbleCreateOpClassStmt(jstate, expr);
+				break;
+			case T_CreateOpClassItem:
+				_jumbleCreateOpClassItem(jstate, expr);
+				break;
+			case T_CreateOpFamilyStmt:
+				_jumbleCreateOpFamilyStmt(jstate, expr);
+				break;
+			case T_AlterOpFamilyStmt:
+				_jumbleAlterOpFamilyStmt(jstate, expr);
+				break;
+			case T_DropStmt:
+				_jumbleDropStmt(jstate, expr);
+				break;
+			case T_TruncateStmt:
+				_jumbleTruncateStmt(jstate, expr);
+				break;
+			case T_CommentStmt:
+				_jumbleCommentStmt(jstate, expr);
+				break;
+			case T_SecLabelStmt:
+				_jumbleSecLabelStmt(jstate, expr);
+				break;
+			case T_DeclareCursorStmt:
+				_jumbleDeclareCursorStmt(jstate, expr);
+				break;
+			case T_ClosePortalStmt:
+				_jumbleClosePortalStmt(jstate, expr);
+				break;
+			case T_FetchStmt:
+				_jumbleFetchStmt(jstate, expr);
+				break;
+			case T_IndexStmt:
+				_jumbleIndexStmt(jstate, expr);
+				break;
+			case T_CreateStatsStmt:
+				_jumbleCreateStatsStmt(jstate, expr);
+				break;
+			case T_StatsElem:
+				_jumbleStatsElem(jstate, expr);
+				break;
+			case T_AlterStatsStmt:
+				_jumbleAlterStatsStmt(jstate, expr);
+				break;
+			case T_CreateFunctionStmt:
+				_jumbleCreateFunctionStmt(jstate, expr);
+				break;
+			case T_FunctionParameter:
+				_jumbleFunctionParameter(jstate, expr);
+				break;
+			case T_AlterFunctionStmt:
+				_jumbleAlterFunctionStmt(jstate, expr);
+				break;
+			case T_DoStmt:
+				_jumbleDoStmt(jstate, expr);
+				break;
+			case T_CallStmt:
+				_jumbleCallStmt(jstate, expr);
+				break;
+			case T_RenameStmt:
+				_jumbleRenameStmt(jstate, expr);
+				break;
+			case T_AlterObjectDependsStmt:
+				_jumbleAlterObjectDependsStmt(jstate, expr);
+				break;
+			case T_AlterObjectSchemaStmt:
+				_jumbleAlterObjectSchemaStmt(jstate, expr);
+				break;
+			case T_AlterOwnerStmt:
+				_jumbleAlterOwnerStmt(jstate, expr);
+				break;
+			case T_AlterOperatorStmt:
+				_jumbleAlterOperatorStmt(jstate, expr);
+				break;
+			case T_AlterTypeStmt:
+				_jumbleAlterTypeStmt(jstate, expr);
+				break;
+			case T_RuleStmt:
+				_jumbleRuleStmt(jstate, expr);
+				break;
+			case T_NotifyStmt:
+				_jumbleNotifyStmt(jstate, expr);
+				break;
+			case T_ListenStmt:
+				_jumbleListenStmt(jstate, expr);
+				break;
+			case T_UnlistenStmt:
+				_jumbleUnlistenStmt(jstate, expr);
+				break;
+			case T_TransactionStmt:
+				_jumbleTransactionStmt(jstate, expr);
+				break;
+			case T_CompositeTypeStmt:
+				_jumbleCompositeTypeStmt(jstate, expr);
+				break;
+			case T_CreateEnumStmt:
+				_jumbleCreateEnumStmt(jstate, expr);
+				break;
+			case T_CreateRangeStmt:
+				_jumbleCreateRangeStmt(jstate, expr);
+				break;
+			case T_AlterEnumStmt:
+				_jumbleAlterEnumStmt(jstate, expr);
+				break;
+			case T_ViewStmt:
+				_jumbleViewStmt(jstate, expr);
+				break;
+			case T_LoadStmt:
+				_jumbleLoadStmt(jstate, expr);
+				break;
+			case T_CreatedbStmt:
+				_jumbleCreatedbStmt(jstate, expr);
+				break;
+			case T_AlterDatabaseStmt:
+				_jumbleAlterDatabaseStmt(jstate, expr);
+				break;
+			case T_AlterDatabaseRefreshCollStmt:
+				_jumbleAlterDatabaseRefreshCollStmt(jstate, expr);
+				break;
+			case T_AlterDatabaseSetStmt:
+				_jumbleAlterDatabaseSetStmt(jstate, expr);
+				break;
+			case T_DropdbStmt:
+				_jumbleDropdbStmt(jstate, expr);
+				break;
+			case T_AlterSystemStmt:
+				_jumbleAlterSystemStmt(jstate, expr);
+				break;
+			case T_ClusterStmt:
+				_jumbleClusterStmt(jstate, expr);
+				break;
+			case T_VacuumStmt:
+				_jumbleVacuumStmt(jstate, expr);
+				break;
+			case T_VacuumRelation:
+				_jumbleVacuumRelation(jstate, expr);
+				break;
+			case T_ExplainStmt:
+				_jumbleExplainStmt(jstate, expr);
+				break;
+			case T_CreateTableAsStmt:
+				_jumbleCreateTableAsStmt(jstate, expr);
+				break;
+			case T_RefreshMatViewStmt:
+				_jumbleRefreshMatViewStmt(jstate, expr);
+				break;
+			case T_CheckPointStmt:
+				_jumbleCheckPointStmt(jstate, expr);
+				break;
+			case T_DiscardStmt:
+				_jumbleDiscardStmt(jstate, expr);
+				break;
+			case T_LockStmt:
+				_jumbleLockStmt(jstate, expr);
+				break;
+			case T_ConstraintsSetStmt:
+				_jumbleConstraintsSetStmt(jstate, expr);
+				break;
+			case T_ReindexStmt:
+				_jumbleReindexStmt(jstate, expr);
+				break;
+			case T_CreateConversionStmt:
+				_jumbleCreateConversionStmt(jstate, expr);
+				break;
+			case T_CreateCastStmt:
+				_jumbleCreateCastStmt(jstate, expr);
+				break;
+			case T_CreateTransformStmt:
+				_jumbleCreateTransformStmt(jstate, expr);
+				break;
+			case T_PrepareStmt:
+				_jumblePrepareStmt(jstate, expr);
+				break;
+			case T_ExecuteStmt:
+				_jumbleExecuteStmt(jstate, expr);
+				break;
+			case T_DeallocateStmt:
+				_jumbleDeallocateStmt(jstate, expr);
+				break;
+			case T_DropOwnedStmt:
+				_jumbleDropOwnedStmt(jstate, expr);
+				break;
+			case T_ReassignOwnedStmt:
+				_jumbleReassignOwnedStmt(jstate, expr);
+				break;
+			case T_AlterTSDictionaryStmt:
+				_jumbleAlterTSDictionaryStmt(jstate, expr);
+				break;
+			case T_AlterTSConfigurationStmt:
+				_jumbleAlterTSConfigurationStmt(jstate, expr);
+				break;
+			case T_PublicationTable:
+				_jumblePublicationTable(jstate, expr);
+				break;
+			case T_PublicationObjSpec:
+				_jumblePublicationObjSpec(jstate, expr);
+				break;
+			case T_CreatePublicationStmt:
+				_jumbleCreatePublicationStmt(jstate, expr);
+				break;
+			case T_AlterPublicationStmt:
+				_jumbleAlterPublicationStmt(jstate, expr);
+				break;
+			case T_CreateSubscriptionStmt:
+				_jumbleCreateSubscriptionStmt(jstate, expr);
+				break;
+			case T_AlterSubscriptionStmt:
+				_jumbleAlterSubscriptionStmt(jstate, expr);
+				break;
+			case T_DropSubscriptionStmt:
+				_jumbleDropSubscriptionStmt(jstate, expr);
+				break;
+			case T_GroupByOrdering:
+				_jumbleGroupByOrdering(jstate, expr);
+				break;
+			case T_Result:
+				_jumbleResult(jstate, expr);
+				break;
+			case T_ProjectSet:
+				_jumbleProjectSet(jstate, expr);
+				break;
+			case T_ModifyTable:
+				_jumbleModifyTable(jstate, expr);
+				break;
+			case T_Append:
+				_jumbleAppend(jstate, expr);
+				break;
+			case T_MergeAppend:
+				_jumbleMergeAppend(jstate, expr);
+				break;
+			case T_RecursiveUnion:
+				_jumbleRecursiveUnion(jstate, expr);
+				break;
+			case T_BitmapAnd:
+				_jumbleBitmapAnd(jstate, expr);
+				break;
+			case T_BitmapOr:
+				_jumbleBitmapOr(jstate, expr);
+				break;
+			case T_SeqScan:
+				_jumbleSeqScan(jstate, expr);
+				break;
+			case T_SampleScan:
+				_jumbleSampleScan(jstate, expr);
+				break;
+			case T_IndexScan:
+				_jumbleIndexScan(jstate, expr);
+				break;
+			case T_IndexOnlyScan:
+				_jumbleIndexOnlyScan(jstate, expr);
+				break;
+			case T_BitmapIndexScan:
+				_jumbleBitmapIndexScan(jstate, expr);
+				break;
+			case T_BitmapHeapScan:
+				_jumbleBitmapHeapScan(jstate, expr);
+				break;
+			case T_TidScan:
+				_jumbleTidScan(jstate, expr);
+				break;
+			case T_TidRangeScan:
+				_jumbleTidRangeScan(jstate, expr);
+				break;
+			case T_SubqueryScan:
+				_jumbleSubqueryScan(jstate, expr);
+				break;
+			case T_FunctionScan:
+				_jumbleFunctionScan(jstate, expr);
+				break;
+			case T_ValuesScan:
+				_jumbleValuesScan(jstate, expr);
+				break;
+			case T_TableFuncScan:
+				_jumbleTableFuncScan(jstate, expr);
+				break;
+			case T_CteScan:
+				_jumbleCteScan(jstate, expr);
+				break;
+			case T_NamedTuplestoreScan:
+				_jumbleNamedTuplestoreScan(jstate, expr);
+				break;
+			case T_WorkTableScan:
+				_jumbleWorkTableScan(jstate, expr);
+				break;
+			case T_ForeignScan:
+				_jumbleForeignScan(jstate, expr);
+				break;
+			case T_CustomScan:
+				_jumbleCustomScan(jstate, expr);
+				break;
+			case T_NestLoop:
+				_jumbleNestLoop(jstate, expr);
+				break;
+			case T_NestLoopParam:
+				_jumbleNestLoopParam(jstate, expr);
+				break;
+			case T_MergeJoin:
+				_jumbleMergeJoin(jstate, expr);
+				break;
+			case T_HashJoin:
+				_jumbleHashJoin(jstate, expr);
+				break;
+			case T_Material:
+				_jumbleMaterial(jstate, expr);
+				break;
+			case T_Memoize:
+				_jumbleMemoize(jstate, expr);
+				break;
+			case T_Sort:
+				_jumbleSort(jstate, expr);
+				break;
+			case T_IncrementalSort:
+				_jumbleIncrementalSort(jstate, expr);
+				break;
+			case T_Group:
+				_jumbleGroup(jstate, expr);
+				break;
+			case T_Agg:
+				_jumbleAgg(jstate, expr);
+				break;
+			case T_WindowAgg:
+				_jumbleWindowAgg(jstate, expr);
+				break;
+			case T_Unique:
+				_jumbleUnique(jstate, expr);
+				break;
+			case T_Gather:
+				_jumbleGather(jstate, expr);
+				break;
+			case T_GatherMerge:
+				_jumbleGatherMerge(jstate, expr);
+				break;
+			case T_Hash:
+				_jumbleHash(jstate, expr);
+				break;
+			case T_SetOp:
+				_jumbleSetOp(jstate, expr);
+				break;
+			case T_LockRows:
+				_jumbleLockRows(jstate, expr);
+				break;
+			case T_Limit:
+				_jumbleLimit(jstate, expr);
+				break;
+			case T_ExtensibleNode:
+				_jumbleExtensibleNode(jstate, expr);
+				break;
+			case T_Integer:
+				_jumbleInteger(jstate, expr);
+				break;
+			case T_Float:
+				_jumbleFloat(jstate, expr);
+				break;
+			case T_Boolean:
+				_jumbleBoolean(jstate, expr);
+				break;
+			case T_String:
+				_jumbleString(jstate, expr);
+				break;
+			case T_BitString:
+				_jumbleBitString(jstate, expr);
+				break;


### PR DESCRIPTION
This was already done manually for the initial release, but not
documented, and source branches were not published. Remediate, and in
passing adjust 18 plan ID jumbling slightly:

- Ignore WindowAgg.winname and ModifyTable.returning(OldAlias|NewAlias)
- Reformat per upstream node generation script without pgindent run
- Define _jumbleParam in jumblefuncs.c, like upstream does

In passing, sync up functions responsible for squashed lists on PG18+
with the actual in-tree code.