### PR TITLE
Use pending statistics correctly to fix data race

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ SELECT * FROM pg_stat_plans(false);
 (5 rows)
 ```
 
+**Important:** Due to using the Postgres cumulative statistics system, statistics counters in all current Postgres versions are
+only flushed at transaction end with an up to 60 second delay to avoid lock contention. Entries will still be present with
+their plan text, but with call counts not yet updated. Work is ongoing upstream to improve this in future Postgres releases.
+
 You can also group by `queryid` retrieved from `pg_stat_statements`, to get the different plans chosen for the same query. For example, we can see different plans being chosen based on whether a table was expected to have data or not, and Postgres falling back to a sequential scan and in efficient Hash Join incorrectly:
 
 ```sql

--- a/compat_16_17/expected/privileges.out
+++ b/compat_16_17/expected/privileges.out
@@ -14,18 +14,55 @@ SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t
 (1 row)
 
-SELECT 1 AS "ONE";
- ONE 
------
-   1
+SELECT 1 AS "SUPER";
+ SUPER 
+-------
+     1
 (1 row)
 
 SET ROLE regress_stats_user1;
+SELECT 1+1 AS "ONE";
+ ONE 
+-----
+   2
+(1 row)
+
+SET ROLE regress_stats_user2;
 SELECT 1+1 AS "TWO";
  TWO 
 -----
    2
 (1 row)
+
+-- Wait for pending stats to be flushed
+SET ROLE regress_stats_superuser;
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+--
+-- regress_stats_user1 has no privileges to read the plan text, queryid
+-- or planid of queries executed by others but can see statistics
+-- like calls and rows.
+--
+-- We run this before the other tests so that we don't have a surprising
+-- "<insufficient privilege>" entry from other roles checking pg_stat_plans.
+--
+SET ROLE regress_stats_user1;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
+  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
+  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
+         rolname         | queryid_bool | planid_bool |           plan           | calls 
+-------------------------+--------------+-------------+--------------------------+-------
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_user1     | t            | t           | Result                   |     1
+ regress_stats_user2     |              |             | <insufficient privilege> |     1
+(5 rows)
 
 --
 -- A superuser can read all columns of queries executed by others,
@@ -34,30 +71,16 @@ SELECT 1+1 AS "TWO";
 SET ROLE regress_stats_superuser;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
          rolname         | queryid_bool | planid_bool |  plan  | calls 
 -------------------------+--------------+-------------+--------+-------
  regress_stats_superuser | t            | t           | Result |     1
  regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
  regress_stats_user1     | t            | t           | Result |     1
-(3 rows)
-
---
--- regress_stats_user1 has no privileges to read the plan text, queryid
--- or planid of queries executed by others but can see statistics
--- like calls and rows.
---
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
-  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
-  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |           plan           | calls 
--------------------------+--------------+-------------+--------------------------+-------
- regress_stats_superuser |              |             | <insufficient privilege> |     1
- regress_stats_superuser |              |             | <insufficient privilege> |     1
- regress_stats_superuser |              |             | <insufficient privilege> |     1
- regress_stats_user1     | t            | t           | Result                   |     1
-(4 rows)
+ regress_stats_user2     | t            | t           | Result |     1
+(5 rows)
 
 --
 -- regress_stats_user2, with pg_read_all_stats role privileges, can
@@ -67,26 +90,15 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool
 SET ROLE regress_stats_user2;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user1     | t            | t           | Result                                                                             |     1
- regress_stats_user1     | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
+         rolname         | queryid_bool | planid_bool |  plan  | calls 
+-------------------------+--------------+-------------+--------+-------
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_user1     | t            | t           | Result |     1
+ regress_stats_user2     | t            | t           | Result |     1
 (5 rows)
 
 --

--- a/compat_16_17/expected/select.out
+++ b/compat_16_17/expected/select.out
@@ -31,6 +31,13 @@ SELECT 1 FROM pg_class WHERE relname = 'pg_class';
 (1 row)
 
 SET enable_indexscan = on;
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                              plan                             | calls 
 --------------------------------------------------------------+-------
@@ -43,7 +50,8 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
  Limit                                                       +|     1
    ->  Seq Scan on pg_class                                   | 
  Result                                                       |     1
-(4 rows)
+ Result                                                       |     1
+(5 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -73,6 +81,13 @@ SELECT a.attname,
  tableoid | 
 (1 row)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                      plan                                      | calls 
 -------------------------------------------------------------------------------+-------
@@ -88,7 +103,8 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                  ->  Seq Scan on pg_attrdef d                                 +| 
                        Filter: ((adrelid = a.attrelid) AND (adnum = a.attnum)) | 
  Result                                                                        |     1
-(3 rows)
+ Result                                                                        |     1
+(4 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -166,6 +182,13 @@ select * from lp where a not in ('a', 'd');
 ---
 (0 rows)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                       plan                                      | calls 
 --------------------------------------------------------------------------------+-------
@@ -237,13 +260,14 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
    ->  Seq Scan on lp_default lp_4                                             +| 
          Filter: (a <> ALL ('{a,d}'::bpchar[]))                                 | 
  Result                                                                         |     1
+ Result                                                                         |     1
  Seq Scan on lp_ad lp                                                          +|     1
    Filter: ('a'::bpchar = a)                                                    | 
  Seq Scan on lp_ad lp                                                          +|     1
    Filter: (a = 'a'::bpchar)                                                    | 
  Seq Scan on lp_null lp                                                        +|     1
    Filter: (a IS NULL)                                                          | 
-(13 rows)
+(14 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 

--- a/compat_18/expected/privileges.out
+++ b/compat_18/expected/privileges.out
@@ -14,18 +14,55 @@ SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t
 (1 row)
 
-SELECT 1 AS "ONE";
- ONE 
------
-   1
+SELECT 1 AS "SUPER";
+ SUPER 
+-------
+     1
 (1 row)
 
 SET ROLE regress_stats_user1;
+SELECT 1+1 AS "ONE";
+ ONE 
+-----
+   2
+(1 row)
+
+SET ROLE regress_stats_user2;
 SELECT 1+1 AS "TWO";
  TWO 
 -----
    2
 (1 row)
+
+-- Wait for pending stats to be flushed
+SET ROLE regress_stats_superuser;
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+--
+-- regress_stats_user1 has no privileges to read the plan text, queryid
+-- or planid of queries executed by others but can see statistics
+-- like calls and rows.
+--
+-- We run this before the other tests so that we don't have a surprising
+-- "<insufficient privilege>" entry from other roles checking pg_stat_plans.
+--
+SET ROLE regress_stats_user1;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
+  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
+  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
+         rolname         | queryid_bool | planid_bool |           plan           | calls 
+-------------------------+--------------+-------------+--------------------------+-------
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_user1     | t            | t           | Result                   |     1
+ regress_stats_user2     |              |             | <insufficient privilege> |     1
+(5 rows)
 
 --
 -- A superuser can read all columns of queries executed by others,
@@ -34,43 +71,15 @@ SELECT 1+1 AS "TWO";
 SET ROLE regress_stats_superuser;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user1     | t            | t           | Result                                                                             |     1
-(4 rows)
-
---
--- regress_stats_user1 has no privileges to read the plan text, queryid
--- or planid of queries executed by others but can see statistics
--- like calls and rows.
---
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
-  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
-  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_user1     | t            | t           | Result                                                                             |     1
- regress_stats_user1     | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
+         rolname         | queryid_bool | planid_bool |  plan  | calls 
+-------------------------+--------------+-------------+--------+-------
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_user1     | t            | t           | Result |     1
+ regress_stats_user2     | t            | t           | Result |     1
 (5 rows)
 
 --
@@ -81,34 +90,16 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool
 SET ROLE regress_stats_user2;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user1     | t            | t           | Result                                                                             |     1
- regress_stats_user1     | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user2     | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
-(6 rows)
+         rolname         | queryid_bool | planid_bool |  plan  | calls 
+-------------------------+--------------+-------------+--------+-------
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_user1     | t            | t           | Result |     1
+ regress_stats_user2     | t            | t           | Result |     1
+(5 rows)
 
 --
 -- cleanup

--- a/compat_18/expected/select.out
+++ b/compat_18/expected/select.out
@@ -31,6 +31,13 @@ SELECT 1 FROM pg_class WHERE relname = 'pg_class';
 (1 row)
 
 SET enable_indexscan = on;
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                              plan                             | calls 
 --------------------------------------------------------------+-------
@@ -43,10 +50,11 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
  Limit                                                       +|     1
    ->  Seq Scan on pg_class                                   | 
  Result                                                       |     1
+ Result                                                       |     1
  Sort                                                        +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                  +| 
    ->  Function Scan on pg_stat_plans                         | 
-(5 rows)
+(6 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -76,6 +84,13 @@ SELECT a.attname,
  tableoid | 
 (1 row)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                      plan                                      | calls 
 -------------------------------------------------------------------------------+-------
@@ -91,10 +106,11 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                  ->  Seq Scan on pg_attrdef d                                 +| 
                        Filter: ((adrelid = a.attrelid) AND (adnum = a.attnum)) | 
  Result                                                                        |     1
+ Result                                                                        |     1
  Sort                                                                         +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                                   +| 
    ->  Function Scan on pg_stat_plans                                          | 
-(4 rows)
+(5 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -172,6 +188,13 @@ select * from lp where a not in ('a', 'd');
 ---
 (0 rows)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                       plan                                      | calls 
 --------------------------------------------------------------------------------+-------
@@ -243,6 +266,7 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
    ->  Seq Scan on lp_default lp_4                                             +| 
          Filter: (a <> ALL ('{a,d}'::bpchar[]))                                 | 
  Result                                                                         |     1
+ Result                                                                         |     1
  Seq Scan on lp_ad lp                                                          +|     1
    Filter: ('a'::bpchar = a)                                                    | 
  Seq Scan on lp_ad lp                                                          +|     1
@@ -252,7 +276,7 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
  Sort                                                                          +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                                    +| 
    ->  Function Scan on pg_stat_plans                                           | 
-(14 rows)
+(15 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 

--- a/expected/privileges.out
+++ b/expected/privileges.out
@@ -14,18 +14,55 @@ SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t
 (1 row)
 
-SELECT 1 AS "ONE";
- ONE 
------
-   1
+SELECT 1 AS "SUPER";
+ SUPER 
+-------
+     1
 (1 row)
 
 SET ROLE regress_stats_user1;
+SELECT 1+1 AS "ONE";
+ ONE 
+-----
+   2
+(1 row)
+
+SET ROLE regress_stats_user2;
 SELECT 1+1 AS "TWO";
  TWO 
 -----
    2
 (1 row)
+
+-- Wait for pending stats to be flushed
+SET ROLE regress_stats_superuser;
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+--
+-- regress_stats_user1 has no privileges to read the plan text, queryid
+-- or planid of queries executed by others but can see statistics
+-- like calls and rows.
+--
+-- We run this before the other tests so that we don't have a surprising
+-- "<insufficient privilege>" entry from other roles checking pg_stat_plans.
+--
+SET ROLE regress_stats_user1;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
+  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
+  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
+         rolname         | queryid_bool | planid_bool |           plan           | calls 
+-------------------------+--------------+-------------+--------------------------+-------
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_superuser |              |             | <insufficient privilege> |     1
+ regress_stats_user1     | t            | t           | Result                   |     1
+ regress_stats_user2     |              |             | <insufficient privilege> |     1
+(5 rows)
 
 --
 -- A superuser can read all columns of queries executed by others,
@@ -34,43 +71,15 @@ SELECT 1+1 AS "TWO";
 SET ROLE regress_stats_superuser;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user1     | t            | t           | Result                                                                             |     1
-(4 rows)
-
---
--- regress_stats_user1 has no privileges to read the plan text, queryid
--- or planid of queries executed by others but can see statistics
--- like calls and rows.
---
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
-  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
-  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_superuser |              |             | <insufficient privilege>                                                           |     1
- regress_stats_user1     | t            | t           | Result                                                                             |     1
- regress_stats_user1     | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
+         rolname         | queryid_bool | planid_bool |  plan  | calls 
+-------------------------+--------------+-------------+--------+-------
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_user1     | t            | t           | Result |     1
+ regress_stats_user2     | t            | t           | Result |     1
 (5 rows)
 
 --
@@ -81,34 +90,16 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool
 SET ROLE regress_stats_user2;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-         rolname         | queryid_bool | planid_bool |                                        plan                                        | calls 
--------------------------+--------------+-------------+------------------------------------------------------------------------------------+-------
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Result                                                                             |     1
- regress_stats_superuser | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user1     | t            | t           | Result                                                                             |     1
- regress_stats_user1     | t            | t           | Sort                                                                              +|     1
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
- regress_stats_user2     | t            | t           | Sort                                                                              +|     0
-                         |              |             |   Sort Key: pg_authid.rolname, pg_stat_plans.plan COLLATE "C", pg_stat_plans.calls+| 
-                         |              |             |   ->  Hash Join                                                                   +| 
-                         |              |             |         Hash Cond: (pg_stat_plans.userid = pg_authid.oid)                         +| 
-                         |              |             |         ->  Function Scan on pg_stat_plans                                        +| 
-                         |              |             |         ->  Hash                                                                  +| 
-                         |              |             |               ->  Seq Scan on pg_authid                                            | 
-(6 rows)
+         rolname         | queryid_bool | planid_bool |  plan  | calls 
+-------------------------+--------------+-------------+--------+-------
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_superuser | t            | t           | Result |     1
+ regress_stats_user1     | t            | t           | Result |     1
+ regress_stats_user2     | t            | t           | Result |     1
+(5 rows)
 
 --
 -- cleanup

--- a/expected/select.out
+++ b/expected/select.out
@@ -31,6 +31,13 @@ SELECT 1 FROM pg_class WHERE relname = 'pg_class';
 (1 row)
 
 SET enable_indexscan = on;
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                              plan                             | calls 
 --------------------------------------------------------------+-------
@@ -43,10 +50,11 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
  Limit                                                       +|     1
    ->  Seq Scan on pg_class                                   | 
  Result                                                       |     1
+ Result                                                       |     1
  Sort                                                        +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                  +| 
    ->  Function Scan on pg_stat_plans                         | 
-(5 rows)
+(6 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -76,6 +84,13 @@ SELECT a.attname,
  tableoid | 
 (1 row)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                      plan                                      | calls 
 -------------------------------------------------------------------------------+-------
@@ -91,10 +106,11 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                  ->  Seq Scan on pg_attrdef d                                 +| 
                        Filter: ((adrelid = a.attrelid) AND (adnum = a.attnum)) | 
  Result                                                                        |     1
+ Result                                                                        |     1
  Sort                                                                         +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                                   +| 
    ->  Function Scan on pg_stat_plans                                          | 
-(4 rows)
+(5 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 
@@ -172,6 +188,13 @@ select * from lp where a not in ('a', 'd');
 ---
 (0 rows)
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
                                       plan                                      | calls 
 --------------------------------------------------------------------------------+-------
@@ -243,6 +266,7 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
    ->  Seq Scan on lp_default lp_4                                             +| 
          Filter: (a <> ALL ('{a,d}'::bpchar[]))                                 | 
  Result                                                                         |     1
+ Result                                                                         |     1
  Seq Scan on lp_ad lp                                                          +|     1
    Filter: ('a'::bpchar = a)                                                    | 
  Seq Scan on lp_ad lp                                                          +|     1
@@ -252,7 +276,7 @@ SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
  Sort                                                                          +|     0
    Sort Key: pg_stat_plans.plan COLLATE "C"                                    +| 
    ->  Function Scan on pg_stat_plans                                           | 
-(14 rows)
+(15 rows)
 
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
  t 

--- a/pg_stat_plans.c
+++ b/pg_stat_plans.c
@@ -605,7 +605,7 @@ pgstat_report_plan_stats(QueryDesc *queryDesc,
 {
 	PgStat_EntryRef *entry_ref;
 	PgStatShared_Plan *shstatent;
-	PgStat_StatPlanEntry *statent;
+	PgStat_StatPlanEntry *pending;
 	bool		newly_created;
 	uint64		queryId = queryDesc->plannedstmt->queryId;
 	uint64		planId;
@@ -622,7 +622,7 @@ pgstat_report_plan_stats(QueryDesc *queryDesc,
 										  PGSTAT_PLAN_IDX(queryId, planId, userid, toplevel), &newly_created);
 
 	shstatent = (PgStatShared_Plan *) entry_ref->shared_stats;
-	statent = &shstatent->stats;
+	pending = (PgStat_StatPlanEntry *) entry_ref->pending;
 
 	if (newly_created)
 	{
@@ -663,9 +663,9 @@ pgstat_report_plan_stats(QueryDesc *queryDesc,
 		pfree(plan);
 	}
 
-	statent->exec_count += exec_count;
-	statent->exec_time += exec_time;
-	statent->usage += USAGE_INCREASE;
+	pending->exec_count += exec_count;
+	pending->exec_time += exec_time;
+	pending->usage += USAGE_INCREASE;
 }
 
 static void

--- a/sql/privileges.sql
+++ b/sql/privileges.sql
@@ -11,10 +11,32 @@ GRANT pg_read_all_stats TO regress_stats_user2;
 
 SET ROLE regress_stats_superuser;
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
-SELECT 1 AS "ONE";
+SELECT 1 AS "SUPER";
 
 SET ROLE regress_stats_user1;
+SELECT 1+1 AS "ONE";
+
+SET ROLE regress_stats_user2;
 SELECT 1+1 AS "TWO";
+
+-- Wait for pending stats to be flushed
+SET ROLE regress_stats_superuser;
+SELECT pg_sleep(1);
+
+--
+-- regress_stats_user1 has no privileges to read the plan text, queryid
+-- or planid of queries executed by others but can see statistics
+-- like calls and rows.
+--
+-- We run this before the other tests so that we don't have a surprising
+-- "<insufficient privilege>" entry from other roles checking pg_stat_plans.
+--
+
+SET ROLE regress_stats_user1;
+SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
+  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
+  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
 
 --
 -- A superuser can read all columns of queries executed by others,
@@ -22,19 +44,10 @@ SELECT 1+1 AS "TWO";
 --
 
 SET ROLE regress_stats_superuser;
+
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
-  ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
-
---
--- regress_stats_user1 has no privileges to read the plan text, queryid
--- or planid of queries executed by others but can see statistics
--- like calls and rows.
---
-
-SET ROLE regress_stats_user1;
-SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
-  FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
 
 --
@@ -46,6 +59,7 @@ SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool
 SET ROLE regress_stats_user2;
 SELECT r.rolname, ss.queryid <> 0 AS queryid_bool, ss.planid <> 0 AS planid_bool, ss.plan, ss.calls
   FROM pg_stat_plans ss JOIN pg_roles r ON ss.userid = r.oid
+  WHERE ss.plan NOT LIKE '%Function Scan on pg_stat_plans%'
   ORDER BY r.rolname, ss.plan COLLATE "C", ss.calls;
 
 --

--- a/sql/select.sql
+++ b/sql/select.sql
@@ -17,6 +17,9 @@ SET enable_indexscan = off;
 SELECT 1 FROM pg_class WHERE relname = 'pg_class';
 SET enable_indexscan = on;
 
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
+
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
 
@@ -34,6 +37,9 @@ SELECT a.attname,
  FROM pg_catalog.pg_attribute a
  WHERE a.attrelid = 'pg_class'::regclass
  ORDER BY attnum LIMIT 1;
+
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
 
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;
@@ -62,6 +68,9 @@ select * from lp where a is not null and (a = 'a' or a = 'c');
 select * from lp where a <> 'g';
 select * from lp where a <> 'a' and a <> 'd';
 select * from lp where a not in ('a', 'd');
+
+-- Wait for pending stats to be flushed
+SELECT pg_sleep(1);
 
 SELECT plan, calls FROM pg_stat_plans ORDER BY plan COLLATE "C";
 SELECT pg_stat_plans_reset() IS NOT NULL AS t;


### PR DESCRIPTION
Previously we were not actually utilizing the pending statistics local to each backend, instead writing to the shared counters directly. This was not sound, since we were not holding a lock whilst doing that write, causing a potential data race with concurrent writes by other backends.

Fix by instead writing to the local pending queue as intended, and rely on the cumulative statistics system to flush.

This also has a user-facing consequence that statistics counters are only updated once a flush occurs, which is between every 1 to 60 seconds when idle, *after* a transaction has ended.

For tests, since current Postgres releases do not have a way to explicitly flush pending entries, add necessary sleep(1) calls to the tests so that we can read our own writes when testing. This ensures that at least PGSTAT_MIN_INTERVAL (1000ms) have passed and the "flush when idle" handling in PostgresMain is triggered after the sleep. Note that we can't call pgstat_report_stat whilst inside a query / transaction, since it has assert that fails.

In passing, restructure the privileges test for clarity.