### PR TITLE
Optionally capture plan advice string on Postgres 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
             --without-icu --without-readline --without-zlib
           make -j"$(nproc)"
           make install
+          # pg_plan_advice is needed for the plan_advice regression test
+          make -C contrib/pg_plan_advice install || true
           echo "PG_CONFIG=$PGPREFIX/bin/pg_config" >> "$GITHUB_ENV"
 
       - name: Build pg_stat_plans

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJS = \
 	jumblefuncs.o
 
 EXTENSION = pg_stat_plans
-DATA = pg_stat_plans--2.0.sql
+DATA = pg_stat_plans--2.0.sql pg_stat_plans--2.0--2.1.sql
 PGFILEDESC = "pg_stat_plans - track per-plan call counts, execution times and EXPLAIN texts"
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
@@ -31,6 +31,19 @@ endif
 
 ifneq (,$(findstring PostgreSQL 18,$(shell $(PG_CONFIG) --version)))
 	REGRESS_OPTS += --expecteddir=$(PWD)/compat_18
+endif
+
+# On Postgres 19+, additionally exercise pg_plan_advice collection, but only
+# when pg_plan_advice is installed (it must be preloaded for the test). When
+# present, preload both modules for the whole run; the extra module is inert
+# while pg_stat_plans.plan_advice is "off" (the default), so the other tests
+# are unaffected.
+ifneq (,$(findstring PostgreSQL 19,$(shell $(PG_CONFIG) --version)))
+	PLAN_ADVICE_LIB := $(wildcard $(shell $(PG_CONFIG) --pkglibdir)/pg_plan_advice.*)
+	ifneq (,$(PLAN_ADVICE_LIB))
+		REGRESS_OPTS = --temp-config $(srcdir)/pg_plan_advice.conf
+		REGRESS = select activity privileges plan_advice cleanup
+	endif
 endif
 
 EXTRA_CLEAN = tmp_check results regression.diffs regression.out

--- a/README.md
+++ b/README.md
@@ -211,15 +211,16 @@ branch, and using the correct prefix to be used for the files:
 
 ## Configuration
 
-| setting                       | possible values | default | description                                                                                                                 |
-|-------------------------------|-----------------|---------|-----------------------------------------------------------------------------------------------------------------------------|
-| pg_stat_plans.max             | 100 - INT_MAX/2 | 5000    | Sets the maximum number of plans tracked by pg_stat_plans in shared memory.                                                 |
-| pg_stat_plans.max_size        | 100 - 1048576   | 8192    | Sets the maximum size of an individual plan text (in bytes) tracked by pg_stat_plans.                                       |
-| pg_stat_plans.max_plan_memory | 256kB - 2TB     | 16MB    | Sets the total memory limit for plan text storage. When exhausted, new plans are still tracked but without their plan text. |
-| pg_stat_plans.track           | top<br>all      | top     | Selects which plans are tracked by pg_stat_plans.                                                                           |
-| pg_stat_plans.compress        | none<br>zstd    | none    | Select compression used by pg_stat_plans.                                                                                   |
+| setting                       | possible values | default | description                                                                                                                                   |
+|-------------------------------|-----------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| pg_stat_plans.max             | 100 - INT_MAX/2 | 5000    | Sets the maximum number of plans tracked by pg_stat_plans in shared memory.                                                                   |
+| pg_stat_plans.max_size        | 100 - 1048576   | 8192    | Sets the maximum size of an individual plan text (in bytes) tracked by pg_stat_plans.                                                         |
+| pg_stat_plans.max_plan_memory | 256kB - 2TB     | 16MB    | Sets the total memory limit for plan text storage. When exhausted, new plans are still tracked but without their plan text.                   |
+| pg_stat_plans.track           | top<br>all      | top     | Selects which plans are tracked by pg_stat_plans.                                                                                             |
+| pg_stat_plans.compress        | none<br>zstd    | none    | Select compression used by pg_stat_plans.                                                                                                     |
+| pg_stat_plans.plan_advice     | off<br>on       | off     | Collects a `pg_plan_advice` string for each tracked plan on Postgres 19 or newer with `pg_plan_advice` loaded via `shared_preload_libraries`. |
 
-All configuration settings can be changed with a reload (`SIGHUP`). `max_size`, `track` and `compress` can also be set by superusers on a per connection basis.
+All configuration settings can be changed with a reload (`SIGHUP`). `max_size`, `track`, `compress` and `plan_advice` can also be set by superusers on a per connection basis.
 
 The 8kB default for `max_size` is chosen to keep plan text values under the limit for "smaller sizes" for Postgres dynamic shared memory area (DSA) used for plan texts. Up to that size, plan texts come from pooled, fixed-size superblocks that freed entries reuse efficiently; larger ones are instead allocated in blocks of individual 4kB DSA pages, rounded up from the actual size needed.
 

--- a/expected/plan_advice.out
+++ b/expected/plan_advice.out
@@ -1,0 +1,74 @@
+--
+-- pg_plan_advice string collection (Postgres 19+ only)
+--
+-- This test is only run when pg_plan_advice is available and preloaded
+-- alongside pg_stat_plans (see the Makefile). The extension was already
+-- created by the "select" test.
+--
+-- Disable parallelism so the chosen plans (and thus the generated advice)
+-- are deterministic.
+SET max_parallel_workers_per_gather = 0;
+CREATE TABLE pa_t1(id int primary key, x int);
+CREATE TABLE pa_t2(id int primary key, t1_id int);
+INSERT INTO pa_t1 SELECT g, g FROM generate_series(1, 1000) g;
+INSERT INTO pa_t2 SELECT g, g % 1000 + 1 FROM generate_series(1, 5000) g;
+ANALYZE pa_t1, pa_t2;
+--
+-- off: advice is never collected, even on repeated execution
+--
+SET pg_stat_plans.plan_advice = off;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+ count 
+-------
+    99
+(1 row)
+
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+ count 
+-------
+    99
+(1 row)
+
+SELECT plan_advice IS NULL AS advice_is_null
+  FROM pg_stat_plans WHERE plan LIKE '%pa_t1%' AND plan NOT LIKE '%pg_stat_plans%';
+ advice_is_null 
+----------------
+ t
+(1 row)
+
+--
+-- on: advice is collected on the first execution
+--
+SET pg_stat_plans.plan_advice = on;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+ count 
+-------
+    99
+(1 row)
+
+SELECT plan_advice IS NOT NULL AS advice_present
+  FROM pg_stat_plans WHERE plan LIKE '%pa_t1%' AND plan NOT LIKE '%pg_stat_plans%';
+ advice_present 
+----------------
+ t
+(1 row)
+
+DROP TABLE pa_t1, pa_t2;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;
+ t 
+---
+ t
+(1 row)
+

--- a/pg_plan_advice.conf
+++ b/pg_plan_advice.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'pg_stat_plans,pg_plan_advice'

--- a/pg_stat_plans--2.0--2.1.sql
+++ b/pg_stat_plans--2.0--2.1.sql
@@ -1,0 +1,39 @@
+/* contrib/pg_stat_plans/pg_stat_plans--2.0--2.1.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pg_stat_plans UPDATE TO '2.1'" to load this file. \quit
+
+-- Adding the plan_advice output column changes the result type of
+-- pg_stat_plans(boolean), so the dependent views and the function must be
+-- dropped and recreated.
+DROP VIEW pg_stat_plans_activity;
+DROP VIEW pg_stat_plans;
+DROP FUNCTION pg_stat_plans(boolean);
+
+CREATE FUNCTION pg_stat_plans(IN showplan boolean,
+    OUT userid oid,
+    OUT dbid oid,
+    OUT toplevel bool,
+    OUT queryid int8,
+    OUT planid int8,
+    OUT calls int8,
+    OUT total_exec_time float8,
+    OUT plan text,
+    OUT plan_advice text
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_stat_plans_2_0'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE VIEW pg_stat_plans AS
+  SELECT * FROM pg_stat_plans(true);
+
+GRANT SELECT ON pg_stat_plans TO PUBLIC;
+
+CREATE VIEW pg_stat_plans_activity AS
+  SELECT a.pid, a.plan_id, p.plan, p.plan_advice
+    FROM pg_stat_plans_get_activity(NULL) a
+    JOIN pg_stat_plans(true) p
+         ON (a.datid = p.dbid AND a.usesysid = p.userid AND a.query_id = p.queryid AND a.plan_id = p.planid AND p.toplevel IS TRUE);
+
+GRANT SELECT ON pg_stat_plans_activity TO PUBLIC;

--- a/pg_stat_plans.c
+++ b/pg_stat_plans.c
@@ -28,11 +28,13 @@
 #include "lib/dshash.h"
 #include "libpq/auth.h"
 #include "mb/pg_wchar.h"
+#include "nodes/parsenodes.h"
 #include "nodes/queryjumble.h"
 #include "optimizer/planner.h"
 #include "parser/analyze.h"
 #include "pgstat.h"
 #if PG_VERSION_NUM >= 190000
+#include "storage/dsm_registry.h"
 #include "utils/pgstat_internal.h"
 #endif
 #include "storage/ipc.h"
@@ -108,6 +110,7 @@ static int	pgsp_max_size = 8192;	/* max size of plan text to track (in
 static int	pgsp_track = PGSP_TRACK_TOP;	/* tracking level */
 static int	pgsp_compress = PGSP_COMPRESS_NONE; /* compression type */
 static int	pgsp_max_plan_memory = 16384;	/* plan text DSA size limit, in KB */
+static bool pgsp_plan_advice = false;	/* collect pg_plan_advice strings */
 
 /*
  * Module shared state, provisioned via the DSM registry (PG18+) or the shmem
@@ -169,6 +172,11 @@ typedef struct PgStatShared_PlanInfo
 										 * truncated due to text size limit */
 	int			plan_text_compression;	/* plan compression used */
 	int			plan_encoding;	/* plan text encoding */
+
+	dsa_pointer plan_advice;	/* pointer into the plan-text DSA holding the
+								 * pg_plan_advice string (Postgres 19+),
+								 * InvalidDsaPointer if absent or the DSA was full */
+	size_t		plan_advice_size;	/* size of stored advice (incl. NUL) */
 }			PgStatShared_PlanInfo;
 
 typedef struct PgStat_StatPlanEntry
@@ -386,10 +394,10 @@ pgsp_dealloc_entries(void)
 		PgStatShared_HashEntry *p;
 
 		/*
-		 * Free the plan text before dropping the entry. If we left it for
-		 * pgstat_gc_plan_memory() to free later, a concurrent resurrection of
-		 * the entry by pgstat_reinit_entry() could cause a query text leak,
-		 * since reinit does a memset and through that zeroes our DSA pointer.
+		 * Free the plan text (and any advice string) before dropping the entry.
+		 * If we left it for pgsp_dealloc_release() to free later, a concurrent
+		 * resurrection of the entry by pgstat_reinit_entry() could cause a leak,
+		 * since reinit does a memset and through that zeroes our DSA pointers.
 		 */
 		p = dshash_find(pgStatCustomLocal.shared_hash, &entry->key, true);
 		if (p != NULL)
@@ -404,6 +412,11 @@ pgsp_dealloc_entries(void)
 			{
 				dsa_free(pgsp_plan_dsa, statent->info.plan_text);
 				statent->info.plan_text = InvalidDsaPointer;
+			}
+			if (DsaPointerIsValid(statent->info.plan_advice))
+			{
+				dsa_free(pgsp_plan_dsa, statent->info.plan_advice);
+				statent->info.plan_advice = InvalidDsaPointer;
 			}
 			LWLockRelease(&header->lock);
 
@@ -495,14 +508,19 @@ pgsp_dealloc_release(void)
 		statent = (PgStat_StatPlanEntry *) pgstat_custom_get_entry_data(PGSTAT_KIND_PLANS, header);
 
 		/*
-		 * Free the plan text, if any was still stored, from the DSA. We don't
-		 * need a header lock here since we hold the partition lock exclusively
-		 * and with refcount = 1 no backend holds a direct reference.
+		 * Free the plan text (and any advice string), if still stored, from the
+		 * DSA. We don't need a header lock here since we hold the partition lock
+		 * exclusively and with refcount = 1 no backend holds a direct reference.
 		 */
 		if (DsaPointerIsValid(statent->info.plan_text))
 		{
 			dsa_free(pgsp_plan_dsa, statent->info.plan_text);
 			statent->info.plan_text = InvalidDsaPointer;
+		}
+		if (DsaPointerIsValid(statent->info.plan_advice))
+		{
+			dsa_free(pgsp_plan_dsa, statent->info.plan_advice);
+			statent->info.plan_advice = InvalidDsaPointer;
 		}
 
 		/* Drop our extra reference (1 -> 0) and free the entry. */
@@ -734,6 +752,79 @@ pgsp_decompress_plan_text(char *stored_plan, size_t stored_plan_size, int stored
 	pg_unreachable();
 }
 
+#if PG_VERSION_NUM >= 190000
+
+/*
+ * Signature of pg_plan_advice_request_advice_generation(), resolved at runtime
+ * so that we don't have a hard link-time dependency on pg_plan_advice.
+ */
+typedef void (*pgsp_request_advice_generation_fn) (bool activate);
+
+static pgsp_request_advice_generation_fn pgsp_advice_fn = NULL;
+static bool pgsp_advice_fn_resolved = false;
+
+/*
+ * Resolve pg_plan_advice_request_advice_generation() if pg_plan_advice is
+ * loaded. We only attempt the lookup when pg_plan_advice is listed in
+ * shared_preload_libraries, since load_external_function() would otherwise
+ * raise an error when the library is not present. Returns NULL when advice
+ * generation cannot be triggered.
+ */
+static pgsp_request_advice_generation_fn
+pgsp_get_advice_fn(void)
+{
+	if (!pgsp_advice_fn_resolved)
+	{
+		const char *preload;
+
+		pgsp_advice_fn_resolved = true;
+
+		preload = GetConfigOption("shared_preload_libraries", true, false);
+		if (preload != NULL && strstr(preload, "pg_plan_advice") != NULL)
+			pgsp_advice_fn = (pgsp_request_advice_generation_fn)
+				load_external_function("$libdir/pg_plan_advice",
+									   "pg_plan_advice_request_advice_generation",
+									   false, NULL);
+	}
+
+	return pgsp_advice_fn;
+}
+
+/*
+ * Extract the generated pg_plan_advice string from a planned statement, if
+ * pg_plan_advice stashed one in PlannedStmt.extension_state. Returns NULL when
+ * no advice is present.
+ */
+static char *
+pgsp_get_plan_advice(PlannedStmt *pstmt)
+{
+	ListCell   *lc;
+	List	   *pgpa_list = NIL;
+
+	foreach(lc, pstmt->extension_state)
+	{
+		DefElem    *item = (DefElem *) lfirst(lc);
+
+		if (strcmp(item->defname, "pg_plan_advice") == 0)
+		{
+			pgpa_list = (List *) item->arg;
+			break;
+		}
+	}
+
+	foreach(lc, pgpa_list)
+	{
+		DefElem    *item = (DefElem *) lfirst(lc);
+
+		if (strcmp(item->defname, "advice_string") == 0)
+			return strVal(item->arg);
+	}
+
+	return NULL;
+}
+
+#endif							/* PG_VERSION_NUM >= 190000 */
+
 static void
 pgstat_report_plan_stats(QueryDesc *queryDesc,
 						 PgStat_Counter exec_count,
@@ -810,6 +901,8 @@ pgstat_report_plan_stats(QueryDesc *queryDesc,
 			shstatent->stats.info.plan_text_compression = 0;
 		}
 		shstatent->stats.info.plan_encoding = GetDatabaseEncoding();
+		shstatent->stats.info.plan_advice = InvalidDsaPointer;
+		shstatent->stats.info.plan_advice_size = 0;
 
 		/*
 		 * Take an extra reference so pgstat can't free the entry (and orphan
@@ -834,6 +927,48 @@ pgstat_report_plan_stats(QueryDesc *queryDesc,
 
 		pfree(plan);
 	}
+
+#if PG_VERSION_NUM >= 190000
+	/*
+	 * Record the pg_plan_advice string for this plan, if we don't have it yet.
+	 * The advice is generated during planning (when we requested it via
+	 * pgsp_planner) and stashed in PlannedStmt.extension_state.
+	 */
+	if (pgsp_plan_advice &&
+		!DsaPointerIsValid(shstatent->stats.info.plan_advice))
+	{
+		char	   *advice = pgsp_get_plan_advice(queryDesc->plannedstmt);
+
+		if (advice != NULL && advice[0] != '\0')
+		{
+			size_t		advice_size = strlen(advice) + 1;
+
+			(void) pgstat_custom_lock_entry(entry_ref, false);
+
+			/* re-check under lock, another backend may have stored it */
+			if (!DsaPointerIsValid(shstatent->stats.info.plan_advice))
+			{
+				/*
+				 * Store the advice in the same size-limited DSA as the plan
+				 * text. If that DSA is full, keep the entry but without advice
+				 * (DSA_ALLOC_NO_OOM returns InvalidDsaPointer rather than
+				 * erroring).
+				 */
+				dsa_pointer advice_dp =
+					dsa_allocate_extended(pgsp_plan_dsa, advice_size, DSA_ALLOC_NO_OOM);
+
+				if (DsaPointerIsValid(advice_dp))
+				{
+					memcpy(dsa_get_address(pgsp_plan_dsa, advice_dp), advice, advice_size);
+					shstatent->stats.info.plan_advice = advice_dp;
+					shstatent->stats.info.plan_advice_size = advice_size;
+				}
+			}
+
+			pgstat_custom_unlock_entry(entry_ref);
+		}
+	}
+#endif
 
 	pending->exec_count += exec_count;
 	pending->exec_time += exec_time;
@@ -962,6 +1097,31 @@ pgsp_planner(Query *parse,
 #endif
 {
 	PlannedStmt *result;
+#if PG_VERSION_NUM >= 190000
+	bool		capture_advice = false;
+	pgsp_request_advice_generation_fn advice_fn = NULL;
+
+	/*
+	 * Decide whether to ask pg_plan_advice to generate a plan advice string
+	 * for this query. We only do this for queries we would actually track. The
+	 * advice ends up in PlannedStmt.extension_state and is recorded in
+	 * pgstat_report_plan_stats.
+	 *
+	 * Note: nesting_level has not been incremented yet, so pgsp_enabled()
+	 * reflects this query, matching the check done after planning below.
+	 */
+	if (pgsp_plan_advice &&
+		parse->queryId != UINT64CONST(0) &&
+		pgsp_enabled(nesting_level))
+	{
+		advice_fn = pgsp_get_advice_fn();
+		if (advice_fn != NULL)
+			capture_advice = true;
+	}
+
+	if (capture_advice)
+		advice_fn(true);
+#endif
 
 	/*
 	 * Increment the nesting level, to ensure that functions evaluated during
@@ -989,6 +1149,10 @@ pgsp_planner(Query *parse,
 	PG_FINALLY();
 	{
 		nesting_level--;
+#if PG_VERSION_NUM >= 190000
+		if (capture_advice)
+			advice_fn(false);
+#endif
 	}
 	PG_END_TRY();
 
@@ -1538,6 +1702,17 @@ _PG_init(void)
 							 NULL,
 							 NULL);
 
+	DefineCustomBoolVariable("pg_stat_plans.plan_advice",
+							 "Collect pg_plan_advice strings for tracked plans.",
+							 "Only effective on Postgres 19 or newer with pg_plan_advice loaded.",
+							 &pgsp_plan_advice,
+							 false,
+							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+
 	MarkGUCPrefixReserved("pg_stat_plans");
 
 	/*
@@ -1602,7 +1777,7 @@ pg_stat_plans_reset(PG_FUNCTION_ARGS)
 Datum
 pg_stat_plans_2_0(PG_FUNCTION_ARGS)
 {
-#define PG_STAT_PLANS_COLS 8
+#define PG_STAT_PLANS_COLS 9
 	bool		showplan = PG_GETARG_BOOL(0);
 	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
 	Oid			userid = GetUserId();
@@ -1692,6 +1867,24 @@ pg_stat_plans_2_0(PG_FUNCTION_ARGS)
 		{
 			nulls[i++] = true;
 		}
+
+		/* plan_advice (Postgres 19+; always NULL otherwise) */
+#if PG_VERSION_NUM >= 190000
+		if (showplan && (is_allowed_role || statent->info.userid == userid) &&
+			DsaPointerIsValid(statent->info.plan_advice))
+		{
+			char	   *astr = dsa_get_address(pgsp_plan_dsa, statent->info.plan_advice);
+
+			values[i++] = CStringGetTextDatum(astr);
+		}
+		else
+		{
+			nulls[i++] = true;
+		}
+#else
+		nulls[i++] = true;
+#endif
+
 		tuplestore_putvalues(rsinfo->setResult, rsinfo->setDesc, values, nulls);
 	}
 	dshash_seq_term(&hstat);

--- a/pg_stat_plans.control
+++ b/pg_stat_plans.control
@@ -1,5 +1,5 @@
 # pg_stat_plans extension
 comment = 'track per-plan call counts, execution times and EXPLAIN texts'
-default_version = '2.0'
+default_version = '2.1'
 module_pathname = '$libdir/pg_stat_plans'
 relocatable = true

--- a/sql/plan_advice.sql
+++ b/sql/plan_advice.sql
@@ -1,0 +1,39 @@
+--
+-- pg_plan_advice string collection (Postgres 19+ only)
+--
+-- This test is only run when pg_plan_advice is available and preloaded
+-- alongside pg_stat_plans (see the Makefile). The extension was already
+-- created by the "select" test.
+--
+
+-- Disable parallelism so the chosen plans (and thus the generated advice)
+-- are deterministic.
+SET max_parallel_workers_per_gather = 0;
+
+CREATE TABLE pa_t1(id int primary key, x int);
+CREATE TABLE pa_t2(id int primary key, t1_id int);
+INSERT INTO pa_t1 SELECT g, g FROM generate_series(1, 1000) g;
+INSERT INTO pa_t2 SELECT g, g % 1000 + 1 FROM generate_series(1, 5000) g;
+ANALYZE pa_t1, pa_t2;
+
+--
+-- off: advice is never collected, even on repeated execution
+--
+SET pg_stat_plans.plan_advice = off;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+SELECT plan_advice IS NULL AS advice_is_null
+  FROM pg_stat_plans WHERE plan LIKE '%pa_t1%' AND plan NOT LIKE '%pg_stat_plans%';
+
+--
+-- on: advice is collected on the first execution
+--
+SET pg_stat_plans.plan_advice = on;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;
+SELECT count(*) FROM pa_t1 WHERE x < 100;
+SELECT plan_advice IS NOT NULL AS advice_present
+  FROM pg_stat_plans WHERE plan LIKE '%pa_t1%' AND plan NOT LIKE '%pg_stat_plans%';
+
+DROP TABLE pa_t1, pa_t2;
+SELECT pg_stat_plans_reset() IS NOT NULL AS t;


### PR DESCRIPTION
When enabled with the new pg_stat_plans.plan_advice setting, plan advice will be tracked during each query's planning cycle, and the generated advice will be stored in shared memory for the first execution of a given plan ID. This is similar to running EXPLAIN (PLAN_ADVICE) on the query and helps determine the advice strings that can reproduce a given plan.